### PR TITLE
Update CHANGELOG 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Copyright transferred to trustlines foundation
 - Every call to `user.address` has been replaced with `await user.getAddress`
 
-### Removed
-
-- Obsolete parameters `serializedWallet` and `progressCallback` in `user.createOnboardingMsg`
-
 ### Fixed
 
 - Bug when using `Web3Signer` via MetaMask which referenced an empty address
 - Wrong devDependency of `reconnecting-websocket` which should be a normal dependency
+
+### BREAKING
+
+- Removed obsolete parameters `serializedWallet` and `progressCallback` in `user.createOnboardingMsg` (only mandatory parameter is now `username`)
 
 ## [0.3.0] - 2019-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0] - 2019-04-10
+
+### Added
+
+- Additional option `feePayer` in `payment.prepare` which specifies who pays network fees for transfer
+- `IdentityWallet` for creating and interacting with identity contracts
+- Additional configuration option `walletType` for initializing `TLNetwork` instance
+  - Defaults to `'WalletTypeEthers'`
+  - When using `'WalletTypeIdentity'` it enables meta-transactions which are relayed by configured relay server
+- Basic example app for using clientlib with injected web3 instance via MetaMask under `/examples/injected-web3`
+
+### Changed
+
+- Copyright transferred to trustlines foundation
+- Every call to `user.address` has been replaced with `await user.getAddress`
+
+### Removed
+
+- Obsolete parameters `serializedWallet` and `progressCallback` in `user.createOnboardingMsg`
+
+### Fixed
+
+- Bug when using `Web3Signer` via MetaMask which referenced an empty address
+- Wrong devDependency of `reconnecting-websocket` which should be a normal dependency
+
 ## [0.3.0] - 2019-02-15
 
 Minor breaking change due to migration to `ethers.js`. The API itself did not change, but keystore files of previous versions are not compatible with the new library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustlines-clientlib",
-  "version": "0.3.1-0",
+  "version": "0.4.0",
   "description": "Javascript library for interacting with the trustlines network protocol",
   "main": "lib-esm/TLNetwork.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustlines-clientlib",
-  "version": "0.4.0",
+  "version": "0.4.1-0",
   "description": "Javascript library for interacting with the trustlines network protocol",
   "main": "lib-esm/TLNetwork.js",
   "scripts": {

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -58,6 +58,7 @@ export class Payment {
    * @param options.maximumFees Max. transfer fees user is willing to pay.
    * @param options.gasPrice Custom gas price.
    * @param options.gasLimit Custom gas limit.
+   * @param options.feePayer Either `sender` or `receiver`. Specifies who pays network fees.
    */
   public async prepare(
     networkAddress: string,
@@ -153,6 +154,7 @@ export class Payment {
    * @param value Amount to transfer in biggest unit,
    *              i.e. 1.23 if currency network has 2 decimals.
    * @param options Payment options. See `PaymentOptions` for more information.
+   * @param options.feePayer Either `sender` or `receiver`. Specifies who pays network fees.
    * @param options.networkDecimals Decimals of currency network can be provided manually.
    * @param options.maximumHops Max. number of hops for transfer.
    * @param options.maximumFees Max. transfer fees user if willing to pay.


### PR DESCRIPTION
Aims to close https://github.com/trustlines-protocol/clientlib/issues/217. But missing step would be to run
```bash
yarn bump minor
```
on the master branch which updates the version in `package.json`, adds a git tag with the updated version and triggers the deploy job on CircleCI.