### PR TITLE
Fix reconnecting-websocket in react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "reconnecting-websocket": "^4.1.10",
     "rxjs": "^5.4.1",
     "simple-jsonrpc-js": "0.0.10",
-    "trustlines-contracts-abi": "dev"
+    "trustlines-contracts-abi": "dev",
+    "ws": "^6.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
     "bignumber.js": "7.2.1",
     "ethereumjs-util": "^5.2.0",
     "ethers": "^4.0.23",
-    "html5-websocket": "^2.0.2",
-    "reconnecting-websocket": "^3.0.7",
+    "reconnecting-websocket": "^4.1.10",
     "rxjs": "^5.4.1",
     "simple-jsonrpc-js": "0.0.10",
     "trustlines-contracts-abi": "dev"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,11 @@
 import { BigNumber } from 'bignumber.js'
 import * as ethUtils from 'ethereumjs-util'
-import * as WebSocket from 'html5-websocket'
-import * as ReconnectingWebSocket from 'reconnecting-websocket'
+import ReconnectingWebSocket from 'reconnecting-websocket'
 import 'rxjs/add/operator/map'
 import 'rxjs/add/operator/mergeMap'
 import { Observable } from 'rxjs/Observable'
 import { Observer } from 'rxjs/Observer'
-import * as JsonRPC from 'simple-jsonrpc-js'
+import JsonRPC from 'simple-jsonrpc-js'
 
 import {
   Amount,
@@ -60,8 +59,7 @@ export const websocketStream = (
   args: object
 ): Observable<any> => {
   return Observable.create((observer: Observer<any>) => {
-    const options = { constructor: WebSocket }
-    const ws = new ReconnectingWebSocket(url, undefined, options)
+    const ws = new ReconnectingWebSocket(url)
     const jrpc = new JsonRPC()
 
     jrpc.toStream = (message: string) => {
@@ -93,7 +91,7 @@ export const websocketStream = (
     }
 
     return () => {
-      ws.close(1000, '', { keepClosed: true })
+      ws.close(1000, '')
     }
   })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import 'rxjs/add/operator/mergeMap'
 import { Observable } from 'rxjs/Observable'
 import { Observer } from 'rxjs/Observer'
 import JsonRPC from 'simple-jsonrpc-js'
+import NodeWebSocket from 'ws'
 
 import {
   Amount,
@@ -59,7 +60,10 @@ export const websocketStream = (
   args: object
 ): Observable<any> => {
   return Observable.create((observer: Observer<any>) => {
-    const ws = new ReconnectingWebSocket(url)
+    const options = {
+      WebSocket: (global as any).WebSocket ? undefined : NodeWebSocket
+    }
+    const ws = new ReconnectingWebSocket(url, undefined, options)
     const jrpc = new JsonRPC()
 
     jrpc.toStream = (message: string) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,8 @@ export const websocketStream = (
 ): Observable<any> => {
   return Observable.create((observer: Observer<any>) => {
     const options = {
-      WebSocket: (global as any).WebSocket ? undefined : NodeWebSocket
+      WebSocket: (global as any).WebSocket ? undefined : NodeWebSocket,
+      minReconnectionDelay: 1
     }
     const ws = new ReconnectingWebSocket(url, undefined, options)
     const jrpc = new JsonRPC()

--- a/tests/e2e/CurrencyNetwork.test.ts
+++ b/tests/e2e/CurrencyNetwork.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/e2e/EthWrapper.test.ts
+++ b/tests/e2e/EthWrapper.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/e2e/Exchange.test.ts
+++ b/tests/e2e/Exchange.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { BigNumber } from 'bignumber.js'

--- a/tests/e2e/Messaging.test.ts
+++ b/tests/e2e/Messaging.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/e2e/User.test.ts
+++ b/tests/e2e/User.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/integration/User.test.ts
+++ b/tests/integration/User.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'

--- a/tests/unit/CurrencyNetwork.test.ts
+++ b/tests/unit/CurrencyNetwork.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { CurrencyNetwork } from '../../src/CurrencyNetwork'

--- a/tests/unit/EthersWallet.test.ts
+++ b/tests/unit/EthersWallet.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import { ethers } from 'ethers'
 import 'mocha'
 

--- a/tests/unit/Event.test.ts
+++ b/tests/unit/Event.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { Event } from '../../src/Event'

--- a/tests/unit/IdentityWallet.test.ts
+++ b/tests/unit/IdentityWallet.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLProvider } from '../../src/providers/TLProvider'

--- a/tests/unit/RelayProvider.test.ts
+++ b/tests/unit/RelayProvider.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import fetchMock = require('fetch-mock')
 import 'mocha'
 

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { Trustline } from '../../src/Trustline'

--- a/tests/unit/Typings.test.ts
+++ b/tests/unit/Typings.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { isFeePayerValue } from '../../src/typings'

--- a/tests/unit/User.test.ts
+++ b/tests/unit/User.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { User } from '../../src/User'

--- a/tests/unit/Utils.test.ts
+++ b/tests/unit/Utils.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import fetchMock = require('fetch-mock')
 import 'mocha'
 

--- a/tests/unit/Web3Signer.test.ts
+++ b/tests/unit/Web3Signer.test.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { Web3Signer } from '../../src/signers/Web3Signer'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "sourceMap": true,
     "declaration": true,
     "jsx": "react",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["./src/TLNetwork.ts", "./src/wallets/IdentityWallet.ts"],
   "compileOnSave": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,10 +472,6 @@ async-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async-limiter@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-
 async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -1940,12 +1936,6 @@ hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
-html5-websocket@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/html5-websocket/-/html5-websocket-2.0.4.tgz#531aa0f5b927f7458aaae28003210189d95dec06"
-  dependencies:
-    ws "^3.1.0"
-
 http-proxy@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
@@ -3404,9 +3394,9 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-reconnecting-websocket@^3.0.7:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz#8097514e926e9855e03c39e76efa2e3d1f371bee"
+reconnecting-websocket@^4.1.10:
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-4.1.10.tgz#15485b5c5266ab6dd99187e23e8da207d24c4270"
 
 regenerator-runtime@^0.10.5:
   version "0.10.5"
@@ -4223,10 +4213,6 @@ uglify-js@^3.1.4:
     commander "~2.17.1"
     source-map "~0.6.1"
 
-ultron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -4483,14 +4469,6 @@ write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
-
-ws@^3.1.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
 
 xmlhttprequest@1.8.0:
   version "1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,10 @@ async-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -4469,6 +4473,12 @@ write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+ws@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  dependencies:
+    async-limiter "~1.0.0"
 
 xmlhttprequest@1.8.0:
   version "1.8.0"


### PR DESCRIPTION
Updates the `reconnecting-websocket` dependency and also adds a flag to `tsconfig` which resolves the  `Object is not a constructor` error when trying to use the clientlib in react-native.