### PR TITLE
Add formatting of amount in sent payment request

### DIFF
--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -44,7 +44,10 @@ export class Messaging {
       networkAddress,
       from: await this.user.getAddress(),
       to: counterPartyAddress,
-      amount: utils.calcRaw(value, decimals.networkDecimals).toString(),
+      amount: utils.formatToAmount(
+        utils.calcRaw(value, decimals.networkDecimals),
+        decimals.networkDecimals
+      ),
       subject,
       nonce: utils.generateRandomNumber(20).toNumber()
     }
@@ -59,10 +62,6 @@ export class Messaging {
     })
     return {
       ...paymentRequest,
-      amount: utils.formatToAmount(
-        utils.calcRaw(value, decimals.networkDecimals),
-        decimals.networkDecimals
-      ),
       counterParty: counterPartyAddress,
       direction: 'sent',
       user: await this.user.getAddress()
@@ -83,15 +82,10 @@ export class Messaging {
           if (data.type) {
             return [data]
           }
-          const message = {
+          return Promise.resolve({
             ...JSON.parse(data.message),
             timestamp: data.timestamp
-          }
-          return this.currencyNetwork
-            .getDecimals(message.networkAddress)
-            .then(({ networkDecimals, interestRateDecimals }) =>
-              utils.formatEvent(message, networkDecimals, interestRateDecimals)
-            )
+          })
         })
     )
   }


### PR DESCRIPTION
Previously only the raw value was sent. This lead to inconsistencies as every numerical value returned from the clientlib should be formatted to `Amount`.