### PR TITLE
Feature/provide extra data on transfers

### DIFF
--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -59,12 +59,14 @@ export class Payment {
    * @param options.gasPrice Custom gas price.
    * @param options.gasLimit Custom gas limit.
    * @param options.feePayer Either `sender` or `receiver`. Specifies who pays network fees.
+   * @param extraData Extra data that will appear in the Transfer event when successful
    */
   public async prepare(
     networkAddress: string,
     receiverAddress: string,
     value: number | string,
-    options: PaymentOptions = {}
+    options: PaymentOptions = {},
+    extraData: string = '0x'
   ): Promise<PaymentTxObject> {
     const { gasPrice, gasLimit, networkDecimals } = options
     const decimals = await this.currencyNetwork.getDecimals(networkAddress, {
@@ -78,7 +80,8 @@ export class Payment {
       {
         ...options,
         networkDecimals: decimals.networkDecimals
-      }
+      },
+      extraData
     )
     if (path.length > 0) {
       const {
@@ -96,7 +99,8 @@ export class Payment {
             utils.calcRaw(value, decimals.networkDecimals)
           ),
           utils.convertToHexString(new BigNumber(maxFees.raw)),
-          path.slice(1)
+          path.slice(1),
+          extraData
         ],
         {
           gasLimit: gasLimit
@@ -164,7 +168,8 @@ export class Payment {
     senderAddress: string,
     receiverAddress: string,
     value: number | string,
-    options: PaymentOptions = {}
+    options: PaymentOptions = {},
+    extraData = '0x'
   ): Promise<PathObject> {
     const {
       networkDecimals,
@@ -181,7 +186,8 @@ export class Payment {
       maxFees: maximumFees,
       maxHops: maximumHops,
       to: receiverAddress,
-      value: utils.calcRaw(value, decimals.networkDecimals).toString()
+      value: utils.calcRaw(value, decimals.networkDecimals).toString(),
+      extraData: extraData
     }
     const endpoint = `networks/${networkAddress}/path-info`
     const {

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -46,6 +46,8 @@ export const user3 = {
   pubKey: '3a1430b32ded788f4059ba31cbe6157ac8788f7198d4aed41e1091a97bff2857'
 }
 
+export const extraData = '0x1234'
+
 export function createUsers(tlInstances) {
   return Promise.all(tlInstances.map(tl => tl.user.create()))
 }

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -5,7 +5,12 @@ import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'
 import { FeePayer } from '../../src/typings'
-import { createUsers, parametrizedTLNetworkConfig, wait } from '../Fixtures'
+import {
+  createUsers,
+  extraData,
+  parametrizedTLNetworkConfig,
+  wait
+} from '../Fixtures'
 
 chai.use(chaiAsPromised)
 
@@ -58,7 +63,8 @@ describe('e2e', () => {
             user1.address,
             user2.address,
             1.5,
-            options
+            options,
+            extraData
           )
           expect(pathObj.maxFees).to.have.keys('decimals', 'raw', 'value')
           expect(pathObj.path).to.not.equal([])
@@ -72,7 +78,8 @@ describe('e2e', () => {
             user1.address,
             user2.address,
             1.5,
-            options
+            options,
+            extraData
           )
           expect(pathObj.maxFees).to.have.keys('decimals', 'raw', 'value')
           expect(pathObj.path).to.not.equal([])
@@ -97,7 +104,9 @@ describe('e2e', () => {
           const preparedPayment = await tl1.payment.prepare(
             network.address,
             user2.address,
-            2.25
+            2.25,
+            undefined,
+            extraData
           )
           expect(preparedPayment).to.have.all.keys(
             'rawTx',
@@ -116,7 +125,8 @@ describe('e2e', () => {
             network.address,
             user2.address,
             2.25,
-            options
+            options,
+            extraData
           )
           expect(preparedPayment).to.have.all.keys(
             'rawTx',
@@ -140,7 +150,9 @@ describe('e2e', () => {
           const { rawTx } = await tl1.payment.prepare(
             network.address,
             user2.address,
-            1
+            1,
+            undefined,
+            extraData
           )
           const txId = await tl1.payment.confirm(rawTx)
           await wait()
@@ -153,7 +165,8 @@ describe('e2e', () => {
             network.address,
             user2.address,
             1,
-            options
+            options,
+            extraData
           )
           const txId = await tl1.payment.confirm(rawTx)
           await wait()


### PR DESCRIPTION
closes: https://github.com/trustlines-protocol/clientlib/issues/232
Works in pair with: https://github.com/trustlines-protocol/relay/pull/300 and https://github.com/trustlines-protocol/contracts/pull/208

Do not merge this, will base another PR on top of it for event and needs testing.