### PR TITLE
Pass decimalOptions into methods use getDecimals

### DIFF
--- a/src/CurrencyNetwork.ts
+++ b/src/CurrencyNetwork.ts
@@ -77,14 +77,17 @@ export class CurrencyNetwork {
    */
   public async getUserOverview(
     networkAddress: string,
-    userAddress: string
+    userAddress: string,
+    options: {
+      decimalsOptions?: DecimalsOptions
+    } = {}
   ): Promise<UserOverview> {
     await this._checkAddresses([networkAddress, userAddress])
     const [overview, { networkDecimals }] = await Promise.all([
       this.provider.fetchEndpoint<UserOverviewRaw>(
         `networks/${networkAddress}/users/${userAddress}`
       ),
-      this.getDecimals(networkAddress)
+      this.getDecimals(networkAddress, options.decimalsOptions || {})
     ])
     return {
       balance: utils.formatToAmount(overview.balance, networkDecimals),

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -13,6 +13,7 @@ import {
   AnyExchangeEventRaw,
   AnyNetworkEventRaw,
   AnyTokenEventRaw,
+  DecimalsOptions,
   EventFilterOptions
 } from './typings'
 
@@ -47,7 +48,10 @@ export class Event {
    */
   public async get<T>(
     networkAddress: string,
-    filter: EventFilterOptions = {}
+    filter: EventFilterOptions = {},
+    options: {
+      decimalsOptions?: DecimalsOptions
+    } = {}
   ): Promise<T[]> {
     const baseUrl = `networks/${networkAddress}/users/${await this.user.getAddress()}/events`
     const parameterUrl = utils.buildUrl(baseUrl, filter)
@@ -56,7 +60,10 @@ export class Event {
       { networkDecimals, interestRateDecimals }
     ] = await Promise.all([
       this.provider.fetchEndpoint<AnyNetworkEventRaw[]>(parameterUrl),
-      this.currencyNetwork.getDecimals(networkAddress)
+      this.currencyNetwork.getDecimals(
+        networkAddress,
+        options.decimalsOptions || {}
+      )
     ])
     return events.map(event =>
       utils.formatEvent<T>(event, networkDecimals, interestRateDecimals)

--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -7,7 +7,7 @@ import { User } from './User'
 
 import utils from './utils'
 
-import { PaymentRequestEvent } from './typings'
+import { DecimalsOptions, PaymentRequestEvent } from './typings'
 
 export class Messaging {
   private user: User
@@ -35,9 +35,15 @@ export class Messaging {
     networkAddress: string,
     counterPartyAddress: string,
     value: number | string,
-    subject?: string
+    subject?: string,
+    options: {
+      decimalsOptions?: DecimalsOptions
+    } = {}
   ): Promise<PaymentRequestEvent> {
-    const decimals = await this.currencyNetwork.getDecimals(networkAddress)
+    const decimals = await this.currencyNetwork.getDecimals(
+      networkAddress,
+      options.decimalsOptions || {}
+    )
     const type = 'PaymentRequest'
     const paymentRequest = {
       type,

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -12,6 +12,7 @@ import {
   ClosePathObject,
   ClosePathRaw,
   CloseTxObject,
+  DecimalsOptions,
   EventFilterOptions,
   FeePayer,
   isFeePayerValue,
@@ -21,8 +22,7 @@ import {
   TrustlineObject,
   TrustlineRaw,
   TrustlineUpdateOptions,
-  TxObject,
-  DecimalsOptions
+  TxObject
 } from './typings'
 
 /**

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -21,7 +21,8 @@ import {
   TrustlineObject,
   TrustlineRaw,
   TrustlineUpdateOptions,
-  TxObject
+  TxObject,
+  DecimalsOptions
 } from './typings'
 
 /**
@@ -189,15 +190,24 @@ export class Trustline {
   /**
    * Returns all trustlines of a loaded user in a currency network.
    * @param networkAddress Address of a currency network.
+   * @param options Extra options for user, network or trustline.
    */
-  public async getAll(networkAddress: string): Promise<TrustlineObject[]> {
+  public async getAll(
+    networkAddress: string,
+    options: {
+      decimalsOptions?: DecimalsOptions
+    } = {}
+  ): Promise<TrustlineObject[]> {
     const endpoint = `networks/${networkAddress}/users/${await this.user.getAddress()}/trustlines`
     const [
       trustlines,
       { networkDecimals, interestRateDecimals }
     ] = await Promise.all([
       this.provider.fetchEndpoint<TrustlineRaw[]>(endpoint),
-      this.currencyNetwork.getDecimals(networkAddress)
+      this.currencyNetwork.getDecimals(
+        networkAddress,
+        options.decimalsOptions || {}
+      )
     ])
     return trustlines.map(trustline =>
       this._formatTrustline(trustline, networkDecimals, interestRateDecimals)
@@ -211,7 +221,10 @@ export class Trustline {
    */
   public async get(
     networkAddress: string,
-    counterpartyAddress: string
+    counterpartyAddress: string,
+    options: {
+      decimalsOptions?: DecimalsOptions
+    } = {}
   ): Promise<TrustlineObject> {
     const endpoint = `networks/${networkAddress}/users/${await this.user.getAddress()}/trustlines/${counterpartyAddress}`
     const [
@@ -219,7 +232,10 @@ export class Trustline {
       { networkDecimals, interestRateDecimals }
     ] = await Promise.all([
       this.provider.fetchEndpoint<TrustlineRaw>(endpoint),
-      this.currencyNetwork.getDecimals(networkAddress)
+      this.currencyNetwork.getDecimals(
+        networkAddress,
+        options.decimalsOptions || {}
+      )
     ])
     return this._formatTrustline(
       trustline,


### PR DESCRIPTION
For any method that uses getDecimals function inside, I can pass extra
options argument for this method that conatins decimalsOptions as an
optional param, so getDecimals uses it to avoid an extra server call
happens when getDeciamls calls getInfo inside it. So, if I got decimals
values once, there's no need for redundant calls for getInfo method,
this would save some server requests and enhance performance.