### PR TITLE
Feature/add frozen trustlines status

### DIFF
--- a/src/CurrencyNetwork.ts
+++ b/src/CurrencyNetwork.ts
@@ -91,6 +91,10 @@ export class CurrencyNetwork {
     ])
     return {
       balance: utils.formatToAmount(overview.balance, networkDecimals),
+      frozenBalance: utils.formatToAmount(
+        overview.frozenBalance,
+        networkDecimals
+      ),
       given: utils.formatToAmount(overview.given, networkDecimals),
       leftGiven: utils.formatToAmount(overview.leftGiven, networkDecimals),
       leftReceived: utils.formatToAmount(

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -69,6 +69,7 @@ export interface PaymentOptions extends TLOptions {
 export interface TrustlineUpdateOptions extends TLOptions {
   interestRateGiven?: number
   interestRateReceived?: number
+  isFrozen?: boolean
 }
 
 export interface AmountInternal {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -124,6 +124,7 @@ export interface NetworkTrustlineEventRaw extends NetworkEvent {
   received: string
   interestRateGiven: string
   interestRateReceived: string
+  isFrozen: boolean
 }
 
 export interface NetworkTrustlineEvent extends NetworkEvent {
@@ -131,6 +132,7 @@ export interface NetworkTrustlineEvent extends NetworkEvent {
   received: Amount
   interestRateGiven: Amount
   interestRateReceived: Amount
+  isFrozen: boolean
 }
 
 export type AnyNetworkEvent = NetworkTransferEvent | NetworkTrustlineEvent
@@ -360,6 +362,7 @@ export interface NetworkDetailsRaw extends Network {
 
 export interface UserOverview {
   balance: Amount
+  frozenBalance: Amount
   given: Amount
   received: Amount
   leftGiven: Amount
@@ -369,6 +372,7 @@ export interface UserOverview {
 export interface UserOverviewRaw {
   leftReceived: string
   balance: string
+  frozenBalance: string
   given: string
   received: string
   leftGiven: string
@@ -427,6 +431,7 @@ export interface TrustlineObject {
   leftReceived: Amount
   interestRateGiven: Amount
   interestRateReceived: Amount
+  isFrozen: boolean
 }
 
 export interface TrustlineRaw {
@@ -439,6 +444,7 @@ export interface TrustlineRaw {
   leftReceived: string
   interestRateGiven: string
   interestRateReceived: string
+  isFrozen: boolean
 }
 
 /**

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -172,7 +172,8 @@ export const FAKE_AMOUNT = {
 
 export const FAKE_USER = {
   balance: 100,
-  given: 200,
+  balanceFrozen: 100,
+  given: 300,
   leftGiven: 100,
   leftReceived: 400,
   received: 300
@@ -423,6 +424,7 @@ export const FAKE_TRUSTLINE = {
   id: '123456798',
   interestRateGiven: '1',
   interestRateReceived: '1',
+  isFrozen: false,
   leftGiven: '200',
   leftReceived: '0',
   received: '100'

--- a/tests/e2e/CurrencyNetwork.test.ts
+++ b/tests/e2e/CurrencyNetwork.test.ts
@@ -97,15 +97,24 @@ describe('e2e', () => {
             networks[0].address,
             USER_1.address
           )
-          const { balance, given, received, leftGiven, leftReceived } = overview
+          const {
+            balance,
+            frozenBalance,
+            given,
+            received,
+            leftGiven,
+            leftReceived
+          } = overview
           expect(overview).to.have.all.keys(
             'balance',
+            'frozenBalance',
             'given',
             'received',
             'leftGiven',
             'leftReceived'
           )
           expect(balance).to.have.all.keys('decimals', 'raw', 'value')
+          expect(frozenBalance).to.have.all.keys('decimals', 'raw', 'value')
           expect(given).to.have.all.keys('decimals', 'raw', 'value')
           expect(received).to.have.all.keys('decimals', 'raw', 'value')
           expect(leftGiven).to.have.all.keys('decimals', 'raw', 'value')

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -208,6 +208,9 @@ describe('e2e', () => {
           (updateRequestEvents[0] as NetworkTrustlineEvent).networkAddress
         ).to.equal(network2.address)
         expect(
+          (updateRequestEvents[0] as NetworkTrustlineEvent).isFrozen
+        ).to.be.a('boolean')
+        expect(
           (updateRequestEvents[0] as NetworkTrustlineEvent).given
         ).to.have.keys('raw', 'decimals', 'value')
         expect(
@@ -233,6 +236,9 @@ describe('e2e', () => {
         expect(
           (updateEvents[0] as NetworkTrustlineEvent).networkAddress
         ).to.equal(network2.address)
+        expect(
+          (updateRequestEvents[0] as NetworkTrustlineEvent).isFrozen
+        ).to.be.a('boolean')
         expect((updateEvents[0] as NetworkTrustlineEvent).given).to.have.keys(
           'raw',
           'decimals',
@@ -585,6 +591,7 @@ describe('e2e', () => {
           'value',
           'decimals'
         )
+        expect(trustlineRequestEvent.isFrozen).to.be.a('boolean')
         expect(trustlineRequestEvent).to.have.nested.property(
           'given.value',
           '4001'

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -117,7 +117,9 @@ describe('e2e', () => {
             network.address,
             user2.address,
             2.25,
-            { extraData }
+            {
+              extraData
+            }
           )
           expect(preparedPayment).to.have.all.keys(
             'rawTx',

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -153,6 +153,7 @@ describe('e2e', () => {
         const received = 1000
         const interestRateGiven = 0.01
         const interestRateReceived = 0.02
+        const isFrozen = false
 
         it('should return latest request for network WITHOUT interest rates', async () => {
           const { rawTx } = await tl1.trustline.prepareUpdate(
@@ -202,6 +203,7 @@ describe('e2e', () => {
             'decimals'
           )
           expect(latestRequest.interestRateGiven.value).to.eq('0')
+          expect(latestRequest.isFrozen).to.eq(isFrozen)
           expect(latestRequest.type).to.equal('TrustlineUpdateRequest')
         })
 
@@ -257,6 +259,7 @@ describe('e2e', () => {
           expect(latestRequest.interestRateGiven.value).to.eq(
             networkDefaultInterestRates.defaultInterestRate.value
           )
+          expect(latestRequest.isFrozen).to.eq(isFrozen)
           expect(latestRequest.type).to.equal('TrustlineUpdateRequest')
         })
 
@@ -316,6 +319,7 @@ describe('e2e', () => {
           expect(latestRequest.interestRateGiven.value).to.eq(
             interestRateGiven.toString()
           )
+          expect(latestRequest.isFrozen).to.eq(isFrozen)
           expect(latestRequest.type).to.equal('TrustlineUpdateRequest')
         })
       })
@@ -364,6 +368,7 @@ describe('e2e', () => {
         const received = 2000
         const interestRateGiven = 0.03
         const interestRateReceived = 0.02
+        const isFrozen = false
 
         let acceptTxIdWithoutInterestRates
         let acceptTxIdDefaultInterestRates
@@ -481,6 +486,7 @@ describe('e2e', () => {
             'decimals'
           )
           expect(latestUpdate.interestRateGiven.value).to.eq('0')
+          expect(latestUpdate.isFrozen).to.eq(isFrozen)
         })
 
         it('should return latest update for network with DEFAULT interest rates', async () => {
@@ -523,6 +529,7 @@ describe('e2e', () => {
           expect(latestUpdate.interestRateGiven.value).to.eq(
             networkDefaultInterestRates.defaultInterestRate.value
           )
+          expect(latestUpdate.isFrozen).to.eq(isFrozen)
         })
 
         it('should return latest update for network with CUSTOM interest rates', async () => {
@@ -565,6 +572,7 @@ describe('e2e', () => {
           expect(latestUpdate.interestRateGiven.value).to.eq(
             interestRateGiven.toString()
           )
+          expect(latestUpdate.isFrozen).to.eq(isFrozen)
         })
       })
 
@@ -585,7 +593,8 @@ describe('e2e', () => {
             'leftReceived',
             'received',
             'interestRateGiven',
-            'interestRateReceived'
+            'interestRateReceived',
+            'isFrozen'
           ])
         })
       })

--- a/tests/unit/CurrencyNetwork.test.ts
+++ b/tests/unit/CurrencyNetwork.test.ts
@@ -36,6 +36,7 @@ describe('unit', () => {
     const AMOUNT_KEYS = ['decimals', 'raw', 'value']
     const USER_OVERVIEW_KEYS = [
       'balance',
+      'frozenBalance',
       'given',
       'leftGiven',
       'leftReceived',
@@ -107,6 +108,7 @@ describe('unit', () => {
         )
         assert.hasAllKeys(userOverview, USER_OVERVIEW_KEYS)
         assert.hasAllKeys(userOverview.balance, AMOUNT_KEYS)
+        assert.hasAllKeys(userOverview.frozenBalance, AMOUNT_KEYS)
         assert.hasAllKeys(userOverview.given, AMOUNT_KEYS)
         assert.hasAllKeys(userOverview.leftGiven, AMOUNT_KEYS)
         assert.hasAllKeys(userOverview.leftReceived, AMOUNT_KEYS)

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -80,7 +80,8 @@ describe('unit', () => {
           200,
           {
             interestRateGiven: 0.01,
-            interestRateReceived: 0.02
+            interestRateReceived: 0.02,
+            isFrozen: false
           }
         )
         assert.hasAllKeys(tx, ['rawTx', 'ethFees'])

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -150,6 +150,7 @@ describe('unit', () => {
           'value',
           'raw'
         ])
+        assert.isBoolean(trustlines[0].isFrozen)
       })
     })
 
@@ -167,6 +168,7 @@ describe('unit', () => {
         assert.hasAllKeys(tl.leftReceived, ['decimals', 'value', 'raw'])
         assert.hasAllKeys(tl.interestRateGiven, ['decimals', 'value', 'raw'])
         assert.hasAllKeys(tl.interestRateReceived, ['decimals', 'value', 'raw'])
+        assert.isBoolean(tl.isFrozen)
       })
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,9 +4073,9 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 trustlines-contracts-abi@dev:
-  version "0.7.1-dev5.gf4a92d6"
-  resolved "https://registry.yarnpkg.com/trustlines-contracts-abi/-/trustlines-contracts-abi-0.7.1-dev5.gf4a92d6.tgz#6d4e0d1d8cbad850efa0589f4c716edbd0e1c435"
-  integrity sha512-7nROhNsTcTqfrk1isONTjKP8pMd/lPQMjqvhKdskv2gmmyR2C1YeCBLo86qqEoUuSwKS4I/nuhAwmAdgNc3sVQ==
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/trustlines-contracts-abi/-/trustlines-contracts-abi-0.8.0.tgz#f798d4f00bddb00f6a8b163d8e50b682145fade7"
+  integrity sha512-3E0tjJgIX3qHXVSUSu5HAD7Bc7Nh8X6h915ZDKRrexYwC3sAGMNNEgIb8+kmyHZWBiayWrt8AFXT7thC86m1IA==
 
 ts-node@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
Closes: https://github.com/trustlines-protocol/clientlib/issues/241
closes: https://github.com/trustlines-protocol/clientlib/issues/242

Add information as to whether a trustline is frozen. Since it was not too much work, also add ability to freeze a trustline with `prepareUpdate()`

See https://github.com/trustlines-protocol/relay/pull/313 for updated relay api with frozen TL info
See https://github.com/trustlines-protocol/contracts/pull/233 for new CurrencyNetwork TL update function signatures with `isFrozen` on `updateTrustline()`