### PR TITLE
Add fees and currencyNetworkOfFees to meta-tx

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -227,6 +227,8 @@ export interface RawTxObject {
   gasPrice?: number | string | BigNumber
   data?: string
   nonce?: number
+  delegationFees?: number | string | BigNumber
+  currencyNetworkOfFees?: string
 }
 
 export interface MetaTransaction {
@@ -235,6 +237,8 @@ export interface MetaTransaction {
   to: string
   value: string
   data: string
+  delegationFees: string
+  currencyNetworkOfFees: string
   nonce: string
   signature?: string
 }

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -239,6 +239,8 @@ export class IdentityWallet implements TLWallet {
       'address',
       'uint256',
       'bytes32',
+      'uint64',
+      'address',
       'uint256',
       'bytes'
     ]
@@ -249,6 +251,8 @@ export class IdentityWallet implements TLWallet {
       metaTransaction.to,
       metaTransaction.value,
       ethers.utils.solidityKeccak256(['bytes'], [metaTransaction.data]),
+      metaTransaction.delegationFees,
+      metaTransaction.currencyNetworkOfFees,
       metaTransaction.nonce,
       metaTransaction.extraData
     ]
@@ -346,7 +350,9 @@ export class IdentityWallet implements TLWallet {
       from: rawTx.from,
       nonce: rawTx.nonce.toString(),
       to: rawTx.to,
-      value: rawTx.value.toString()
+      value: rawTx.value.toString(),
+      delegationFees: (rawTx.delegationFees || 0).toString(),
+      currencyNetworkOfFees: rawTx.currencyNetworkOfFees || rawTx.to
     }
 
     return metaTransaction

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -406,7 +406,9 @@ export const FAKE_META_TX = {
   from: '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
   nonce: '1',
   to: '0x51a240271AB8AB9f9a21C82d9a85396b704E164d',
-  value: '0'
+  value: '0',
+  delegationFees: '1',
+  currencyNetworkOfFees: '0x51a240271AB8AB9f9a21C82d9a85396b704E164d'
 }
 
 export const FAKE_META_TX_PRIVATE_KEY =
@@ -415,7 +417,7 @@ export const FAKE_META_TX_PRIVATE_KEY =
 // The signature on the FAKE_META_TX obtained in the tests of the trustlines-network/contracts repository
 // Obtained by signing with key "0x0000...001"
 export const FAKE_META_TX_SIGNATURE =
-  '0x6d2fe56ef6648cb3f0398966ad3b05d891cde786d8074bdac15bcb92ebfa7222489b8eb6ed87165feeede19b031bb69e12036a5fa13b3a46ad0c2c19d051ea9101'
+  '0x02a3c9abd0de925653c188b7f2e6e79ca032037371ef12a560116595508a51b65c1e4692878a87b491ef28e9ee560f7de0f2cb3f0981215134522750d42edce501'
 
 export const FAKE_TRUSTLINE = {
   address: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',

--- a/tests/unit/IdentityWallet.test.ts
+++ b/tests/unit/IdentityWallet.test.ts
@@ -142,11 +142,12 @@ describe('unit', () => {
         )
 
         // check the version number
-        const fakeSignatureVersion = FAKE_META_TX_SIGNATURE.slice(0, -2)
-        const signatureVersion = metaTransaction.signature.slice(0, -2)
+        const fakeSignatureVersion = FAKE_META_TX_SIGNATURE.slice(-2)
+        const signatureVersion = metaTransaction.signature.slice(-2)
         assert.equal(
           parseInt(`0x${signatureVersion}`, 16) % 27,
-          parseInt(fakeSignatureVersion, 16) % 27
+          parseInt(fakeSignatureVersion, 16) % 27,
+          'Signature version number does not match'
         )
       })
     })


### PR DESCRIPTION
closes https://github.com/trustlines-protocol/clientlib/issues/245
Break e2e tests as relay receives unexpected field for meta tx: `fees` and `currencyNetworkOfFees`