### PR TITLE
Add default value of false for isFrozen

### DIFF
--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -76,6 +76,15 @@ export class Trustline {
     creditlineReceived: number | string,
     options: TrustlineUpdateOptions = {}
   ): Promise<TxObject> {
+    // TODO: remove the following quickfix to have a default isFrozen when attempting to update interests rate
+    if (
+      options.interestRateGiven !== undefined &&
+      options.interestRateReceived !== undefined &&
+      options.isFrozen === undefined
+    ) {
+      options.isFrozen = false
+    }
+
     const {
       interestRateGiven,
       interestRateReceived,
@@ -110,7 +119,6 @@ export class Trustline {
     ]
 
     // If interest rates were specified, use `updateTrustline`
-
     if (
       interestRateGiven !== undefined &&
       interestRateReceived !== undefined &&
@@ -136,8 +144,9 @@ export class Trustline {
       interestRateReceived !== undefined ||
       isFrozen !== undefined
     ) {
+      // TODO: once the quick fix for the default value of isFrozen is removed, rewrite the following error message
       throw new Error(
-        'Invalid input parameters: if any of interestRateGiven, interestRateReceived, or isFrozen is given, all have to be given.'
+        'Invalid input parameters: if any of interestRateGiven, or interestRateReceived is given, both have to be given. If isFrozen is given, both interest rates have to be given.'
       )
     }
 

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -86,6 +86,20 @@ describe('unit', () => {
         )
         assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
       })
+
+      it('should return a transaction object with specified interests, with default isFrozen value', async () => {
+        const tx = await trustline.prepareUpdate(
+          FAKE_NETWORK.address,
+          '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18',
+          100,
+          200,
+          {
+            interestRateGiven: 0.01,
+            interestRateReceived: 0.02
+          }
+        )
+        assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
+      })
     })
 
     describe('#prepareAccept()', () => {
@@ -101,12 +115,17 @@ describe('unit', () => {
         assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
       })
 
-      it('should return a transaction object w/o options', async () => {
+      it('should return a transaction object with specified interests', async () => {
         const tx = await trustline.prepareAccept(
           FAKE_NETWORK.address,
           '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18',
           100,
-          200
+          200,
+          {
+            interestRateGiven: 0.01,
+            interestRateReceived: 0.02,
+            isFrozen: false
+          }
         )
         assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
       })


### PR DESCRIPTION
Add default value of false for isFrozen for prepareUpdate (and prepareAccept) when interests are set as a quick fix to be removed later

to allow proper functionning of mobile apps built on top of it.
Needs to be reconsidered after discussion on final solution.