### PR TITLE
Remove the estimateGas field of payment path objects

### DIFF
--- a/src/Exchange.ts
+++ b/src/Exchange.ts
@@ -36,6 +36,7 @@ import {
 const CURRENCY_NETWORK = 'CurrencyNetwork'
 const TOKEN = 'Token'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const DEFAULT_GAS_LIMIT_TAKE_ORDER = 600000
 
 /**
  * The Exchange class contains all methods for making/taking orders, retrieving the orderbook
@@ -352,8 +353,7 @@ export class Exchange {
       {
         gasLimit: gasLimit
           ? new BigNumber(gasLimit)
-          : takerPathObj.estimatedGas
-              .plus(makerPathObj.estimatedGas)
+          : new BigNumber(DEFAULT_GAS_LIMIT_TAKE_ORDER)
               .multipliedBy(1.5)
               .integerValue(),
         gasPrice: gasPrice ? new BigNumber(gasPrice) : undefined
@@ -475,7 +475,6 @@ export class Exchange {
       })
     }
     return {
-      estimatedGas: new BigNumber(40000),
       feePayer: FeePayer.Sender,
       isNetwork: false,
       maxFees: utils.formatToAmount(0, networkDecimals),

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -71,12 +71,7 @@ export class Payment {
     const decimals = await this.currencyNetwork.getDecimals(networkAddress, {
       networkDecimals
     })
-    const {
-      path,
-      maxFees,
-      estimatedGas,
-      feePayer
-    } = await this.getTransferPathInfo(
+    const { path, maxFees, feePayer } = await this.getTransferPathInfo(
       networkAddress,
       await this.user.getAddress(),
       receiverAddress,
@@ -106,9 +101,7 @@ export class Payment {
           extraData || '0x'
         ],
         {
-          gasLimit: gasLimit
-            ? new BigNumber(gasLimit)
-            : new BigNumber(estimatedGas).multipliedBy(1.5).integerValue(),
+          gasLimit: gasLimit ? new BigNumber(gasLimit) : undefined,
           gasPrice: gasPrice ? new BigNumber(gasPrice) : undefined
         }
       )
@@ -194,19 +187,15 @@ export class Payment {
       extraData
     }
     const endpoint = `networks/${networkAddress}/path-info`
-    const {
-      estimatedGas,
-      fees,
-      path,
-      feePayer
-    } = await this.provider.postToEndpoint<PathRaw>(endpoint, data)
+    const { fees, path, feePayer } = await this.provider.postToEndpoint<
+      PathRaw
+    >(endpoint, data)
 
     if (!isFeePayerValue(feePayer)) {
       throw Error(`Unexpected feePayer value: ${feePayer}`)
     }
 
     return {
-      estimatedGas: new BigNumber(estimatedGas),
       feePayer: feePayer as FeePayer,
       maxFees: utils.formatToAmount(fees, decimals.networkDecimals),
       path

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -323,7 +323,7 @@ export class Trustline {
     })
 
     // Get close path
-    const { path, maxFees, estimatedGas, value } = await this.getClosePath(
+    const { path, maxFees, value } = await this.getClosePath(
       networkAddress,
       await this.user.getAddress(),
       counterpartyAddress,
@@ -366,9 +366,7 @@ export class Trustline {
       closeFuncName,
       closeFuncArgs,
       {
-        gasLimit: gasLimit
-          ? new BigNumber(gasLimit)
-          : new BigNumber(estimatedGas).multipliedBy(1.5).integerValue(),
+        gasLimit: gasLimit ? new BigNumber(gasLimit) : undefined,
         gasPrice: gasPrice ? new BigNumber(gasPrice) : undefined
       }
     )
@@ -416,20 +414,15 @@ export class Trustline {
     }
 
     // Request the relay for a path to settle down the trustline.
-    const {
-      path,
-      estimatedGas,
-      fees,
-      value,
-      feePayer
-    } = await this.provider.postToEndpoint<ClosePathRaw>(endpoint, data)
+    const { path, fees, value, feePayer } = await this.provider.postToEndpoint<
+      ClosePathRaw
+    >(endpoint, data)
 
     if (!isFeePayerValue(feePayer)) {
       throw Error(`Unexpected feePayer value: ${feePayer}`)
     }
 
     return {
-      estimatedGas: new BigNumber(estimatedGas),
       feePayer: feePayer as FeePayer,
       maxFees: utils.formatToAmount(fees, decimals.networkDecimals),
       path,

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -337,7 +337,6 @@ export interface PathObject {
   path: string[]
   feePayer: FeePayer
   maxFees: Amount
-  estimatedGas: BigNumber
   isNetwork?: boolean
 }
 
@@ -478,10 +477,6 @@ export interface ClosePathObject {
    */
   maxFees: Amount
   /**
-   * Estimated gas costs for closing
-   */
-  estimatedGas: BigNumber
-  /**
    * Estimated value to be transferred for closing
    */
   value: Amount
@@ -491,7 +486,6 @@ export interface ClosePathRaw {
   path: string[]
   feePayer: string
   fees: string
-  estimatedGas: number
   value: string
 }
 

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -457,7 +457,6 @@ export const FAKE_TRUSTLINE = {
 }
 
 export const FAKE_CLOSE_PATH_RAW = {
-  estimatedGas: '6000000',
   feePayer: 'sender',
   fees: '1000000',
   path: ['0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'],

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -176,6 +176,7 @@ describe('e2e', () => {
           tl2.exchange.prepTakeOrder(order, 1),
           tl1.exchange.prepCancelOrder(order, 1)
         ])
+
         const exTxIds = await Promise.all([
           tl2.exchange.confirm(fillTx.rawTx),
           tl1.exchange.confirm(cancelTx.rawTx)

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -221,13 +221,7 @@ describe('unit', () => {
           FAKE_ACCOUNT.address,
           FAKE_ACCOUNT.address
         )
-        assert.hasAllKeys(closePath, [
-          'estimatedGas',
-          'maxFees',
-          'path',
-          'value',
-          'feePayer'
-        ])
+        assert.hasAllKeys(closePath, ['maxFees', 'path', 'value', 'feePayer'])
       })
     })
 


### PR DESCRIPTION
The exchange used the gas estimate returned from the relay server in the path object. I put a default of 600k gas which was the default in the prepare contract transaction function: https://github.com/trustlines-protocol/clientlib/blob/master/src/Transaction.ts#L53

This default of 600k is now basically used for every transaction (that uses the Ethers wallet and not meta-tx). This is until we discuss how we want to handle gas estimate / whether we want to work with pending blocks, etc ...