### PR TITLE
Add method to retrieve version of configured relay server

### DIFF
--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -102,6 +102,14 @@ export class RelayProvider implements TLProvider {
   }
 
   /**
+   * Returns the version of the currently configured relay server.
+   * @returns Version of relay in the format `relay/vX.X.X`.
+   */
+  public async getRelayVersion(): Promise<string> {
+    return this.fetchEndpoint<string>(`version`)
+  }
+
+  /**
    * Send the given _signedTransaction_ to a relay server to execute it on the
    * blockchain and returns a `Promise` with the transaction hash.
    * @param signedTransaction

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -103,7 +103,7 @@ export class RelayProvider implements TLProvider {
 
   /**
    * Returns the version of the currently configured relay server.
-   * @returns Version of relay in the format `relay/vX.X.X`.
+   * @returns Version of relay in the format `<name>/vX.X.X`.
    */
   public async getRelayVersion(): Promise<string> {
     return this.fetchEndpoint<string>(`version`)

--- a/src/providers/TLProvider.ts
+++ b/src/providers/TLProvider.ts
@@ -17,6 +17,7 @@ export interface TLProvider {
   getTxInfos(userAddress: string): Promise<TxInfos>
   getMetaTxInfos(userAddress: string): Promise<TxInfos>
   getBalance(userAddress: string): Promise<Amount>
+  getRelayVersion(): Promise<string>
   sendSignedTransaction(signedTransaction: string): Promise<string>
   sendSignedMetaTransaction(metaTransaction: MetaTransaction): Promise<string>
 }

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -154,6 +154,13 @@ export class FakeTLProvider implements TLProvider {
     })
   }
 
+  public async getRelayVersion(): Promise<string> {
+    if (this.errors.getRelayVersion) {
+      throw new Error('Mocked error in provider.getRelayVersion()')
+    }
+    return Promise.resolve('relay/v0.1.0')
+  }
+
   public async sendSignedTransaction(
     signedTransaction: string
   ): Promise<string> {

--- a/tests/unit/RelayProvider.test.ts
+++ b/tests/unit/RelayProvider.test.ts
@@ -31,6 +31,7 @@ describe('unit', () => {
       fetchMock.mock('end:/balance', '1000000000')
       fetchMock.mock('end:/blocknumber', JSON.stringify(12345))
       fetchMock.mock('end:/relay', JSON.stringify(FAKE_TX_HASH))
+      fetchMock.mock('end:/version', JSON.stringify('relay/v0.10.0'))
     }
 
     describe('#getBalance()', () => {
@@ -62,6 +63,16 @@ describe('unit', () => {
           FAKE_SIGNED_TX
         )
         assert.isString(txResponse)
+      })
+    })
+
+    describe('#getRelayVersion()', () => {
+      beforeEach(() => init())
+
+      it('return version of relay', async () => {
+        const relayVersion = await relayProvider.getRelayVersion()
+        assert.isString(relayVersion)
+        assert.isTrue(new RegExp(/relay\/v\d/).test(relayVersion))
       })
     })
   })


### PR DESCRIPTION
Adds `getRelayVersion` to `RelayProvider` so that user can fetch the version of current configured relay server.