### PR TITLE
Feature/currency network info is frozen

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -362,6 +362,7 @@ export interface NetworkDetails extends Network {
   interestRateDecimals: number
   customInterests: boolean
   preventMediatorInterests: boolean
+  isFrozen: boolean
 }
 
 export interface NetworkDetailsRaw extends Network {
@@ -371,6 +372,7 @@ export interface NetworkDetailsRaw extends Network {
   interestRateDecimals: number
   customInterests: boolean
   preventMediatorInterests: boolean
+  isFrozen: boolean
 }
 
 export interface UserOverview {

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -172,7 +172,8 @@ export const FAKE_NETWORK = {
   },
   interestRateDecimals: 3,
   name: 'Cash',
-  numUsers: 100
+  numUsers: 100,
+  isFrozen: false
 }
 
 export const FAKE_USER_ADDRESSES = [

--- a/tests/e2e/CurrencyNetwork.test.ts
+++ b/tests/e2e/CurrencyNetwork.test.ts
@@ -28,7 +28,8 @@ describe('e2e', () => {
         'defaultInterestRate',
         'interestRateDecimals',
         'customInterests',
-        'preventMediatorInterests'
+        'preventMediatorInterests',
+        'isFrozen'
       ]
 
       before(async () => {
@@ -58,6 +59,7 @@ describe('e2e', () => {
           expect(networks[0].customInterests).to.be.a('boolean')
           expect(networks[0].preventMediatorInterests).to.be.a('boolean')
           expect(networks[0].interestRateDecimals).to.be.a('number')
+          expect(networks[0].isFrozen).to.be.a('boolean')
         })
       })
 
@@ -80,6 +82,7 @@ describe('e2e', () => {
           expect(networkInfo.customInterests).to.be.a('boolean')
           expect(networkInfo.preventMediatorInterests).to.be.a('boolean')
           expect(networkInfo.interestRateDecimals).to.be.a('number')
+          expect(networkInfo.isFrozen).to.be.a('boolean')
         })
       })
 

--- a/tests/unit/CurrencyNetwork.test.ts
+++ b/tests/unit/CurrencyNetwork.test.ts
@@ -31,7 +31,8 @@ describe('unit', () => {
       'numUsers',
       'defaultInterestRate',
       'interestRateDecimals',
-      'customInterests'
+      'customInterests',
+      'isFrozen'
     ]
     const AMOUNT_KEYS = ['decimals', 'raw', 'value']
     const USER_OVERVIEW_KEYS = [


### PR DESCRIPTION
fixes the end2end tests broken by https://github.com/trustlines-protocol/relay/pull/347 by adding the frozen status to currency network infos