### PR TITLE
Feature/ask meta tx fees

### DIFF
--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -84,7 +84,8 @@ export class Payment {
     if (path.length > 0) {
       const {
         rawTx,
-        ethFees
+        ethFees,
+        delegationFees
       } = await this.transaction.prepareContractTransaction(
         await this.user.getAddress(),
         networkAddress,
@@ -107,6 +108,7 @@ export class Payment {
       )
       return {
         ethFees: utils.convertToAmount(ethFees),
+        delegationFees: utils.convertToDelegationFees(delegationFees),
         feePayer,
         maxFees,
         path,

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -133,7 +133,11 @@ export class Payment {
     options: PaymentOptions = {}
   ): Promise<TxObject> {
     const { gasLimit, gasPrice } = options
-    const { ethFees, rawTx } = await this.transaction.prepareValueTransaction(
+    const {
+      ethFees,
+      rawTx,
+      delegationFees
+    } = await this.transaction.prepareValueTransaction(
       await this.user.getAddress(),
       receiverAddress,
       utils.calcRaw(value, 18),
@@ -144,6 +148,7 @@ export class Payment {
     )
     return {
       ethFees: utils.convertToAmount(ethFees),
+      delegationFees: utils.convertToDelegationFees(delegationFees),
       rawTx
     }
   }

--- a/src/TLNetwork.ts
+++ b/src/TLNetwork.ts
@@ -129,7 +129,8 @@ export class TLNetwork {
     this.currencyNetwork = new CurrencyNetwork(this.provider)
     this.transaction = new Transaction({
       provider: this.provider,
-      signer: this.signer
+      signer: this.signer,
+      currencyNetwork: this.currencyNetwork
     })
     this.user = new User({
       provider: this.provider,

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -36,8 +36,11 @@ export class Transaction {
    * @param contractName name of deployed contract
    * @param functionName name of contract function
    * @param args arguments of function in same order as in contract
-   * @param gasPrice (optional)
-   * @param gasLimit (optional)
+   * @param options.gasPrice (optional)
+   * @param options.gasLimit (optional)
+   * @param options.value (optional)
+   * @param options.delegationFees (optional) delegation fees for a meta transaction.
+   * @param options.currencyNetworkOfFees (optional) currency network of fees for a meta transaction.
    * @returns An ethereum transaction object and the estimated transaction fees in ETH.
    */
   public async prepareContractTransaction(
@@ -62,11 +65,16 @@ export class Transaction {
       to: contractAddress,
       value: options.value || new BigNumber(0)
     }
-    const metaTransactionFees: MetaTransactionFees = await this.signer.getMetaTxFees(
-      rawTx
-    )
-    rawTx.delegationFees = metaTransactionFees.delegationFees
-    rawTx.currencyNetworkOfFees = metaTransactionFees.currencyNetworkOfFees
+    if (options.delegationFees && options.currencyNetworkOfFees) {
+      rawTx.delegationFees = options.delegationFees
+      rawTx.currencyNetworkOfFees = options.currencyNetworkOfFees
+    } else {
+      const metaTransactionFees: MetaTransactionFees = await this.signer.getMetaTxFees(
+        rawTx
+      )
+      rawTx.delegationFees = metaTransactionFees.delegationFees
+      rawTx.currencyNetworkOfFees = metaTransactionFees.currencyNetworkOfFees
+    }
 
     const ethFees = new BigNumber(rawTx.gasLimit).multipliedBy(rawTx.gasPrice)
     return {

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -152,7 +152,8 @@ export class Trustline {
 
     const {
       rawTx,
-      ethFees
+      ethFees,
+      delegationFees
     } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       networkAddress,
@@ -166,6 +167,7 @@ export class Trustline {
     )
     return {
       ethFees: utils.convertToAmount(ethFees),
+      delegationFees: utils.convertToDelegationFees(delegationFees),
       rawTx
     }
   }
@@ -358,7 +360,8 @@ export class Trustline {
     // Prepare the interaction with the contract.
     const {
       rawTx,
-      ethFees
+      ethFees,
+      delegationFees
     } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       networkAddress,
@@ -373,6 +376,7 @@ export class Trustline {
 
     return {
       ethFees: utils.convertToAmount(ethFees),
+      delegationFees: utils.convertToDelegationFees(delegationFees),
       maxFees,
       path,
       rawTx

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -6,7 +6,13 @@ import utils from '../utils'
 
 import { TLProvider } from './TLProvider'
 
-import { Amount, MetaTransaction, TxInfos, TxInfosRaw } from '../typings'
+import {
+  Amount,
+  MetaTransaction,
+  MetaTransactionFees,
+  TxInfos,
+  TxInfosRaw
+} from '../typings'
 
 export class RelayProvider implements TLProvider {
   public relayApiUrl: string
@@ -89,6 +95,23 @@ export class RelayProvider implements TLProvider {
       balance: new BigNumber(balance),
       gasPrice: new BigNumber(0),
       nonce: nextNonce
+    }
+  }
+
+  /**
+   * Returns the fees the provider would be willing to pay for the transaction
+   * @param metaTransaction Meta transaction to be relayed
+   * @returns The fees value and currency network of fees for given meta transaction
+   */
+  public async getMetaTxFees(
+    metaTransaction: MetaTransaction
+  ): Promise<MetaTransactionFees> {
+    const { delegationFees, currencyNetworkOfFees } = await this.postToEndpoint<
+      any
+    >(`/meta-transaction-fees`, { metaTransaction })
+    return {
+      delegationFees,
+      currencyNetworkOfFees
     }
   }
 

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -112,9 +112,14 @@ export class RelayProvider implements TLProvider {
         metaTransaction
       }
     )
-    // For now just get the first possible fee given by the relay server
-    // Could be changed later to show the possible fees to the user and let it decide
-    const { delegationFees, currencyNetworkOfFees } = potentialDelegationFees[0]
+    let delegationFees = '0'
+    let currencyNetworkOfFees = ''
+    if (potentialDelegationFees.length) {
+      // For now just get the first possible fee given by the relay server
+      // Could be changed later to show the possible fees to the user and let it decide
+      delegationFees = potentialDelegationFees[0].delegationFees
+      currencyNetworkOfFees = potentialDelegationFees[0].currencyNetworkOfFees
+    }
     return {
       delegationFees,
       currencyNetworkOfFees

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -10,6 +10,7 @@ import {
   Amount,
   MetaTransaction,
   MetaTransactionFees,
+  NetworkDetailsRaw,
   TxInfos,
   TxInfosRaw
 } from '../typings'

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -106,9 +106,15 @@ export class RelayProvider implements TLProvider {
   public async getMetaTxFees(
     metaTransaction: MetaTransaction
   ): Promise<MetaTransactionFees> {
-    const { delegationFees, currencyNetworkOfFees } = await this.postToEndpoint<
-      any
-    >(`/meta-transaction-fees`, { metaTransaction })
+    const potentialDelegationFees = await this.postToEndpoint<any>(
+      `/meta-transaction-fees`,
+      {
+        metaTransaction
+      }
+    )
+    // For now just get the first possible fee given by the relay server
+    // Could be changed later to show the possible fees to the user and let it decide
+    const { delegationFees, currencyNetworkOfFees } = potentialDelegationFees[0]
     return {
       delegationFees,
       currencyNetworkOfFees

--- a/src/providers/TLProvider.ts
+++ b/src/providers/TLProvider.ts
@@ -1,4 +1,9 @@
-import { Amount, MetaTransaction, TxInfos } from '../typings'
+import {
+  Amount,
+  MetaTransaction,
+  MetaTransactionFees,
+  TxInfos
+} from '../typings'
 
 /**
  * Interface for different provider strategies which extends the given
@@ -16,6 +21,7 @@ export interface TLProvider {
   ): any
   getTxInfos(userAddress: string): Promise<TxInfos>
   getMetaTxInfos(userAddress: string): Promise<TxInfos>
+  getMetaTxFees(metaTransaction: MetaTransaction): Promise<MetaTransactionFees>
   getBalance(userAddress: string): Promise<Amount>
   getRelayVersion(): Promise<string>
   sendSignedTransaction(signedTransaction: string): Promise<string>

--- a/src/signers/TLSigner.ts
+++ b/src/signers/TLSigner.ts
@@ -1,4 +1,10 @@
-import { Amount, RawTxObject, Signature, TxInfos } from '../typings'
+import {
+  Amount,
+  MetaTransactionFees,
+  RawTxObject,
+  Signature,
+  TxInfos
+} from '../typings'
 
 /**
  * Interface for different signer strategies.
@@ -10,4 +16,5 @@ export interface TLSigner {
   signMessage(message: string | ArrayLike<number>): Promise<Signature>
   confirm(rawTx: RawTxObject): Promise<string>
   getTxInfos(userAddress: string): Promise<TxInfos>
+  getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees>
 }

--- a/src/signers/Web3Signer.ts
+++ b/src/signers/Web3Signer.ts
@@ -5,7 +5,13 @@ import { TLSigner } from './TLSigner'
 
 import * as utils from '../utils'
 
-import { Amount, RawTxObject, Signature, TxInfos } from '../typings'
+import {
+  Amount,
+  MetaTransactionFees,
+  RawTxObject,
+  Signature,
+  TxInfos
+} from '../typings'
 
 /**
  * The Web3Signer class contains functions for signing transactions with a web3 provider.
@@ -123,5 +129,12 @@ export class Web3Signer implements TLSigner {
     const balance = new BigNumber(balanceString)
 
     return { balance, gasPrice, nonce }
+  }
+
+  public async getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees> {
+    return {
+      delegationFees: '0',
+      currencyNetworkOfFees: ''
+    }
   }
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -230,11 +230,13 @@ export type AmountEventRaw = NetworkTransferEventRaw | TokenAmountEventRaw
 export interface TxObject {
   rawTx: RawTxObject
   ethFees: Amount
+  delegationFees?: DelegationFeesObject
 }
 
 export interface TxObjectInternal {
   rawTx: RawTxObject
   ethFees: AmountInternal
+  delegationFees?: DelegationFeesInternal
 }
 
 export interface RawTxObject {
@@ -323,6 +325,20 @@ export interface TxInfos {
    * Transaction count of given user address
    */
   nonce: number
+}
+
+export interface DelegationFeesObject {
+  raw: string
+  value: string
+  decimals: number
+  currencyNetworkOfFees: string
+}
+
+export interface DelegationFeesInternal {
+  raw: BigNumber
+  value: BigNumber
+  decimals: number
+  currencyNetworkOfFees: string
 }
 
 // PAYMENT

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -58,6 +58,8 @@ export interface TxOptionsInternal {
   value?: BigNumber
   gasPrice?: BigNumber
   gasLimit?: BigNumber
+  delegationFees?: string
+  currencyNetworkOfFees?: string
 }
 
 export interface TxOptions {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -236,7 +236,7 @@ export interface TxObject {
 export interface TxObjectInternal {
   rawTx: RawTxObject
   ethFees: AmountInternal
-  delegationFees?: DelegationFeesInternal
+  delegationFees: DelegationFeesInternal
 }
 
 export interface RawTxObject {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -259,6 +259,11 @@ export interface MetaTransaction {
   signature?: string
 }
 
+export interface MetaTransactionFees {
+  delegationFees: string
+  currencyNetworkOfFees: string
+}
+
 export interface Web3TxReceipt {
   status: boolean
   blockHash: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,8 @@ import {
   AmountInternal,
   AnyExchangeEvent,
   AnyExchangeEventRaw,
+  DelegationFeesInternal,
+  DelegationFeesObject,
   ExchangeCancelEventRaw,
   ExchangeFillEventRaw
 } from './typings'
@@ -212,6 +214,39 @@ export const formatToAmount = (
 }
 
 /**
+ * Formats number into an AmountInternal object which is intended for internal use.
+ * @param raw Representation of number in smallest unit.
+ * @param decimals Number of decimals.
+ * @param currencyNetworkOfFees the currency network corresponding to the delegation fees
+ */
+export const formatToDelegationFeesInternal = (
+  raw: number | string | BigNumber,
+  decimals: number,
+  currencyNetworkOfFees: string
+): DelegationFeesInternal => {
+  return {
+    decimals,
+    raw: new BigNumber(raw),
+    value: calcValue(raw, decimals),
+    currencyNetworkOfFees
+  }
+}
+
+/**
+ * Formats number into an AmountInternal object which is intended for internal use.
+ * @param delegationFees DelegationFeesInternal object.
+ */
+export const convertToDelegationFees = (
+  delegationFees: DelegationFeesInternal
+): DelegationFeesObject => {
+  return {
+    ...delegationFees,
+    raw: delegationFees.raw.toString(),
+    value: delegationFees.value.toString()
+  }
+}
+
+/**
  * Formats the number values of a raw event returned by the relay.
  * @param event raw event
  * @param networkDecimals decimals of currency network
@@ -398,6 +433,7 @@ export default {
   convertEthToWei,
   convertToAmount,
   convertToHexString,
+  convertToDelegationFees,
   createLink,
   fetchUrl,
   formatEndpoint,
@@ -405,6 +441,7 @@ export default {
   formatExchangeEvent,
   formatToAmount,
   formatToAmountInternal,
+  formatToDelegationFeesInternal,
   generateRandomNumber,
   isURL,
   trimUrl,

--- a/src/wallets/EthersWallet.ts
+++ b/src/wallets/EthersWallet.ts
@@ -15,6 +15,7 @@ import utils from '../utils'
 import {
   Amount,
   EthersWalletData,
+  MetaTransactionFees,
   RawTxObject,
   Signature,
   TxInfos
@@ -269,5 +270,12 @@ export class EthersWallet implements TLWallet {
 
   public async getTxInfos(userAddress: string): Promise<TxInfos> {
     return this.provider.getTxInfos(userAddress)
+  }
+
+  public async getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees> {
+    return {
+      delegationFees: '0',
+      currencyNetworkOfFees: ''
+    }
   }
 }

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -15,6 +15,7 @@ import {
   DeployIdentityResponse,
   IdentityWalletData,
   MetaTransaction,
+  MetaTransactionFees,
   RawTxObject,
   Signature,
   TxInfos
@@ -301,6 +302,13 @@ export class IdentityWallet implements TLWallet {
 
   public async getTxInfos(userAddress: string): Promise<TxInfos> {
     return this.provider.getMetaTxInfos(userAddress)
+  }
+
+  public async getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees> {
+    this.verifyFromField(rawTx)
+
+    const metaTx = this.buildMetaTransaction(rawTx)
+    return this.provider.getMetaTxFees(metaTx)
   }
 
   /**

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -225,6 +225,12 @@ export const FAKE_FUNC_TX_OBJECT_INTERNAL = {
     raw: new BigNumber(1000000000000000000),
     value: new BigNumber(1)
   },
+  delegationFees: {
+    decimals: 18,
+    raw: new BigNumber(1000000000000000000),
+    value: new BigNumber(1),
+    currencyNetworkOfFees: '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18'
+  },
   rawTx: {
     from: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
     gasLimit: new BigNumber(6000000),

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -209,6 +209,12 @@ export const FAKE_VALUE_TX_OBJECT_INTERNAL = {
     raw: new BigNumber(1000000000000000000),
     value: new BigNumber(1)
   },
+  delegationFees: {
+    decimals: 18,
+    raw: new BigNumber(1000000000000000000),
+    value: new BigNumber(1),
+    currencyNetworkOfFees: '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18'
+  },
   rawTx: {
     from: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
     gasLimit: new BigNumber(6000000),

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -35,7 +35,7 @@ describe('e2e', () => {
     const { expect } = chai
 
     let relayProvider: TLProvider
-    let identityWallet: IdentityWallet
+    let identityWallet
     let trustlinesNetwork: TLNetwork
     let trustlinesNetwork2: TLNetwork
 
@@ -50,10 +50,7 @@ describe('e2e', () => {
       trustlinesNetwork = new TLNetwork(tlNetworkConfigIdentity)
       trustlinesNetwork2 = new TLNetwork(tlNetworkConfigIdentity)
 
-      identityWallet = new IdentityWallet(relayProvider, {
-        identityFactoryAddress,
-        identityImplementationAddress
-      })
+      identityWallet = trustlinesNetwork.wallet
     })
 
     describe('Deploy identity', () => {

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -224,5 +224,30 @@ describe('e2e', () => {
         expect(pathObj.feePayer).to.equal(FeePayer.Sender)
       })
     })
+
+    describe('Delegation fees', () => {
+      before(async () => {
+        const walletData = await identityWallet.create()
+        await identityWallet.loadFrom(walletData)
+        await identityWallet.deployIdentity()
+      })
+
+      it('should prepare a transaction and get delegation fees', async () => {
+        const rawTx: RawTxObject = {
+          data: '0x',
+          from: identityWallet.address,
+          nonce: 1,
+          to: identityWallet.address,
+          value: 0
+        }
+
+        const metaTransactionFees = await identityWallet.getMetaTxFees(rawTx)
+        expect(metaTransactionFees).to.have.all.keys(
+          'delegationFees',
+          'currencyNetworkOfFees'
+        )
+        expect(metaTransactionFees.delegationFees).to.equal('0')
+      })
+    })
   })
 })

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -127,6 +127,7 @@ describe('e2e', () => {
             'rawTx',
             'feePayer',
             'ethFees',
+            'delegationFees',
             'maxFees',
             'path'
           )
@@ -143,6 +144,7 @@ describe('e2e', () => {
             'rawTx',
             'feePayer',
             'ethFees',
+            'delegationFees',
             'maxFees',
             'path'
           )
@@ -162,6 +164,7 @@ describe('e2e', () => {
             'rawTx',
             'feePayer',
             'ethFees',
+            'delegationFees',
             'maxFees',
             'path'
           )

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -870,6 +870,7 @@ describe('e2e', () => {
           expect(closeTx).to.have.all.keys([
             'rawTx',
             'ethFees',
+            'delegationFees',
             'maxFees',
             'path'
           ])
@@ -962,6 +963,7 @@ describe('e2e', () => {
           expect(closeTx).to.have.all.keys([
             'rawTx',
             'ethFees',
+            'delegationFees',
             'maxFees',
             'path'
           ])

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -15,7 +15,13 @@ import {
   FAKE_USER_ADDRESSES
 } from '../Fixtures'
 
-import { Amount, MetaTransaction, TxInfos } from '../../src/typings'
+import {
+  Amount,
+  MetaTransaction,
+  MetaTransactionFees,
+  RawTxObject,
+  TxInfos
+} from '../../src/typings'
 
 export class FakeTLProvider implements TLProvider {
   public relayApiUrl = FAKE_RELAY_API
@@ -141,6 +147,15 @@ export class FakeTLProvider implements TLProvider {
       gasPrice: new BigNumber('0'),
       nonce: 1
     })
+  }
+
+  public async getMetaTxFees(
+    metaTransaction: MetaTransaction
+  ): Promise<MetaTransactionFees> {
+    return {
+      delegationFees: '0',
+      currencyNetworkOfFees: metaTransaction.currencyNetworkOfFees
+    }
   }
 
   public async getBalance(userAddress: string): Promise<Amount> {

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -19,6 +19,7 @@ import {
   Amount,
   MetaTransaction,
   MetaTransactionFees,
+  NetworkDetailsRaw,
   RawTxObject,
   TxInfos
 } from '../../src/typings'

--- a/tests/helpers/FakeTLSigner.ts
+++ b/tests/helpers/FakeTLSigner.ts
@@ -1,6 +1,12 @@
 import { TLSigner } from '../../src/signers/TLSigner'
 
-import { Amount, RawTxObject, Signature, TxInfos } from '../../src/typings'
+import {
+  Amount,
+  MetaTransactionFees,
+  RawTxObject,
+  Signature,
+  TxInfos
+} from '../../src/typings'
 
 import {
   FAKE_AMOUNT,
@@ -64,5 +70,12 @@ export class FakeTLSigner implements TLSigner {
 
   public getTxInfos(userAddress: string): Promise<TxInfos> {
     return Promise.resolve(FAKE_TX_INFOS)
+  }
+
+  public async getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees> {
+    return {
+      delegationFees: '0',
+      currencyNetworkOfFees: ''
+    }
   }
 }

--- a/tests/unit/Transaction.test.ts
+++ b/tests/unit/Transaction.test.ts
@@ -60,7 +60,9 @@ describe('unit', () => {
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce'
+          'nonce',
+          'delegationFees',
+          'currencyNetworkOfFees'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, CONTRACT_ADDRESS)
@@ -74,6 +76,8 @@ describe('unit', () => {
         assert.equal(rawTxObject.ethFees.decimals, 18)
         assert.instanceOf(rawTxObject.ethFees.raw, BigNumber)
         assert.instanceOf(rawTxObject.ethFees.value, BigNumber)
+        assert.isString(rawTxObject.rawTx.delegationFees)
+        assert.isString(rawTxObject.rawTx.currencyNetworkOfFees)
       })
 
       it('should prepare a transaction object for calling a function with options', async () => {
@@ -106,7 +110,9 @@ describe('unit', () => {
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce'
+          'nonce',
+          'delegationFees',
+          'currencyNetworkOfFees'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, CONTRACT_ADDRESS)
@@ -131,6 +137,8 @@ describe('unit', () => {
         assert.equal(rawTxObject.ethFees.decimals, 18)
         assert.instanceOf(rawTxObject.ethFees.raw, BigNumber)
         assert.instanceOf(rawTxObject.ethFees.value, BigNumber)
+        assert.isString(rawTxObject.rawTx.delegationFees)
+        assert.isString(rawTxObject.rawTx.currencyNetworkOfFees)
       })
     })
 

--- a/tests/unit/Transaction.test.ts
+++ b/tests/unit/Transaction.test.ts
@@ -8,6 +8,7 @@ import { FakeTLProvider } from '../helpers/FakeTLProvider'
 import { FakeTLSigner } from '../helpers/FakeTLSigner'
 
 import { extraData } from '../Fixtures'
+import { FakeCurrencyNetwork } from '../helpers/FakeCurrencyNetwork'
 
 describe('unit', () => {
   describe('Transaction', () => {
@@ -31,9 +32,11 @@ describe('unit', () => {
     }
 
     before(() => {
+      const provider = new FakeTLProvider()
       transaction = new Transaction({
-        provider: new FakeTLProvider(),
-        signer: new FakeTLSigner()
+        provider,
+        signer: new FakeTLSigner(),
+        currencyNetwork: new FakeCurrencyNetwork(provider)
       })
     })
 
@@ -52,7 +55,7 @@ describe('unit', () => {
             EXTRA_DATA
           ]
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'data',
           'from',
@@ -104,7 +107,7 @@ describe('unit', () => {
             currencyNetworkOfFees: CONTRACT_ADDRESS
           }
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'data',
           'from',

--- a/tests/unit/Transaction.test.ts
+++ b/tests/unit/Transaction.test.ts
@@ -99,7 +99,9 @@ describe('unit', () => {
           {
             gasLimit: new BigNumber(CUSTOM_GAS_LIMIT),
             gasPrice: new BigNumber(CUSTOM_GAS_PRICE),
-            value: new BigNumber(CUSTOM_VALUE)
+            value: new BigNumber(CUSTOM_VALUE),
+            delegationFees: '1',
+            currencyNetworkOfFees: CONTRACT_ADDRESS
           }
         )
         assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees'])
@@ -137,8 +139,8 @@ describe('unit', () => {
         assert.equal(rawTxObject.ethFees.decimals, 18)
         assert.instanceOf(rawTxObject.ethFees.raw, BigNumber)
         assert.instanceOf(rawTxObject.ethFees.value, BigNumber)
-        assert.isString(rawTxObject.rawTx.delegationFees)
-        assert.isString(rawTxObject.rawTx.currencyNetworkOfFees)
+        assert.equal(rawTxObject.rawTx.delegationFees, '1')
+        assert.equal(rawTxObject.rawTx.currencyNetworkOfFees, CONTRACT_ADDRESS)
       })
     })
 

--- a/tests/unit/Transaction.test.ts
+++ b/tests/unit/Transaction.test.ts
@@ -154,14 +154,16 @@ describe('unit', () => {
           COUNTER_PARTY_ADDRESS,
           new BigNumber('1')
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'from',
           'to',
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce'
+          'nonce',
+          'delegationFees',
+          'currencyNetworkOfFees'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, COUNTER_PARTY_ADDRESS)
@@ -189,14 +191,16 @@ describe('unit', () => {
             gasPrice: new BigNumber(CUSTOM_GAS_PRICE)
           }
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'from',
           'to',
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce'
+          'nonce',
+          'delegationFees',
+          'currencyNetworkOfFees'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, COUNTER_PARTY_ADDRESS)

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -38,7 +38,8 @@ describe('unit', () => {
       fakeCurrencyNetwork = new FakeCurrencyNetwork(fakeTLProvider)
       fakeTransaction = new FakeTransaction({
         provider: fakeTLProvider,
-        signer: fakeTLWallet
+        signer: fakeTLWallet,
+        currencyNetwork: fakeCurrencyNetwork
       })
       fakeUser = new FakeUser({
         provider: fakeTLProvider,
@@ -69,7 +70,7 @@ describe('unit', () => {
           100,
           200
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
       })
 
       it('should return a transaction object with specified interests', async () => {
@@ -84,7 +85,7 @@ describe('unit', () => {
             isFrozen: false
           }
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
       })
 
       it('should return a transaction object with specified interests, with default isFrozen value', async () => {
@@ -98,7 +99,7 @@ describe('unit', () => {
             interestRateReceived: 0.02
           }
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
       })
     })
 
@@ -112,7 +113,7 @@ describe('unit', () => {
           100,
           200
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
       })
 
       it('should return a transaction object with specified interests', async () => {
@@ -127,7 +128,7 @@ describe('unit', () => {
             isFrozen: false
           }
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
       })
     })
 
@@ -233,7 +234,13 @@ describe('unit', () => {
           FAKE_NETWORK.address,
           TL_WALLET_DATA.address
         )
-        assert.hasAllKeys(closeTx, ['ethFees', 'maxFees', 'path', 'rawTx'])
+        assert.hasAllKeys(closeTx, [
+          'ethFees',
+          'maxFees',
+          'path',
+          'rawTx',
+          'delegationFees'
+        ])
       })
     })
   })


### PR DESCRIPTION
I decided to ask fro delegation fees when preparing a contract transaction instead of creating an extra step in between preparation and confirmation of transaction.

In `prepareContractTransaction` I could check what signer is used and only get meta transaction fees if the signer is an IdentityWallet (https://github.com/trustlines-protocol/clientlib/pull/269/files#diff-1e657e773ebb13137b9281cc47cdd8efR65). This would allow to remove `getMetaTxFees()` from `EthersWallet` but I was not bothered by it since there are already methods related to identity in there (e.g. `deployIdentity()`).

Closes https://github.com/trustlines-protocol/clientlib/issues/267
the e2e tests will not pass unless this is merged: https://github.com/trustlines-protocol/relay/pull/356