### PR TITLE
Remove install of yarn when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@
 #   docker build . -t e2e
 
 FROM node:10-jessie as builder
-RUN npm install -g yarn
 
 COPY . /clientlib
 WORKDIR /clientlib


### PR DESCRIPTION
It is already installed and will raise an error now https://
github.com/nodejs/docker-node/commit/
d46f9eb95a2db1
2ea29388b3c9b39ba81efe0f51#diff-04c6e90faac2675aa89e2176d2eec7d8