### PR TITLE
Update generateRandomNumber so that it cannot give too high number

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -363,9 +363,13 @@ export const convertToHexString = (
  * @param decimals Decimals which determine size of generated number.
  */
 export const generateRandomNumber = (decimals: number): BigNumber => {
-  return BigNumber.random(decimals + 1)
-    .multipliedBy(new BigNumber(10).pow(decimals))
-    .integerValue()
+  let random = BigNumber.random(decimals + 1)
+  const one = new BigNumber(1)
+
+  while (random === one) {
+    random = BigNumber.random(decimals + 1)
+  }
+  return random.multipliedBy(new BigNumber(10).pow(decimals)).integerValue()
 }
 
 /**


### PR DESCRIPTION
closes: https://github.com/trustlines-protocol/clientlib/issues/277

If the `BigNumber.random(decimals + 1)` results in `1`, the returned number will have one too many decimal. For `decimal = 2` we expect number in between `00` and `99` but we could have `100` as shown in the failing test: https://circleci.com/gh/trustlines-protocol/clientlib/1428.

Another potential choice is to document that 100 is a potential return values.