### PR TITLE
Handle the result of promises in tests

### DIFF
--- a/tests/e2e/CurrencyNetwork.test.ts
+++ b/tests/e2e/CurrencyNetwork.test.ts
@@ -87,8 +87,8 @@ describe('e2e', () => {
       })
 
       describe('#getUsers()', () => {
-        it('should return all user addresses of specific currency network', () => {
-          expect(
+        it('should return all user addresses of specific currency network', async () => {
+          await expect(
             currencyNetwork.getUsers(networks[0].address)
           ).to.eventually.be.an('array')
         })

--- a/tests/e2e/EthWrapper.test.ts
+++ b/tests/e2e/EthWrapper.test.ts
@@ -41,14 +41,16 @@ describe('e2e', () => {
       })
 
       describe('#getAddresses()', () => {
-        it('should return array of wrapper addresses', () => {
-          expect(tl1.ethWrapper.getAddresses()).to.eventually.be.an('array')
+        it('should return array of wrapper addresses', async () => {
+          await expect(tl1.ethWrapper.getAddresses()).to.eventually.be.an(
+            'array'
+          )
         })
       })
 
       describe('#prepDeposit()', () => {
-        it('should prepare a deposit tx', () => {
-          expect(
+        it('should prepare a deposit tx', async () => {
+          await expect(
             tl1.ethWrapper.prepDeposit(ethWrapperAddress, depositAmount)
           ).to.eventually.have.keys('rawTx', 'ethFees')
         })
@@ -71,7 +73,9 @@ describe('e2e', () => {
         })
 
         it('should confirm deposit tx', async () => {
-          expect(tl1.ethWrapper.confirm(tx.rawTx)).to.eventually.be.a('string')
+          await expect(tl1.ethWrapper.confirm(tx.rawTx)).to.eventually.be.a(
+            'string'
+          )
           await wait()
           const [ethBalanceAfter, wethBalanceAfter] = await Promise.all([
             tl1.user.getBalance(),
@@ -93,8 +97,8 @@ describe('e2e', () => {
       })
 
       describe('#prepTransfer()', () => {
-        it('should prepare transfer tx', () => {
-          expect(
+        it('should prepare transfer tx', async () => {
+          await expect(
             tl1.ethWrapper.prepTransfer(
               ethWrapperAddress,
               tl2.user.address,
@@ -135,7 +139,9 @@ describe('e2e', () => {
         })
 
         it('should confirm transfer tx', async () => {
-          expect(tl1.ethWrapper.confirm(tx.rawTx)).to.eventually.be.a('string')
+          await expect(tl1.ethWrapper.confirm(tx.rawTx)).to.eventually.be.a(
+            'string'
+          )
           await wait()
           const [wethBalanceAfter1, ethBalanceAfter2] = await Promise.all([
             tl1.ethWrapper.getBalance(ethWrapperAddress),
@@ -157,8 +163,8 @@ describe('e2e', () => {
       })
 
       describe('#prepWithdraw()', () => {
-        it('should prepare withdraw tx', () => {
-          expect(
+        it('should prepare withdraw tx', async () => {
+          await expect(
             tl1.ethWrapper.prepWithdraw(ethWrapperAddress, withdrawAmount)
           ).to.eventually.have.keys('rawTx', 'ethFees')
         })
@@ -190,7 +196,9 @@ describe('e2e', () => {
         })
 
         it('should confirm withdraw tx', async () => {
-          expect(tl1.ethWrapper.confirm(tx.rawTx)).to.eventually.be.a('string')
+          await expect(tl1.ethWrapper.confirm(tx.rawTx)).to.eventually.be.a(
+            'string'
+          )
           await wait()
           const [ethBalanceAfter, wethBalanceAfter] = await Promise.all([
             tl1.user.getBalance(),

--- a/tests/e2e/Exchange.test.ts
+++ b/tests/e2e/Exchange.test.ts
@@ -82,14 +82,14 @@ describe('e2e', () => {
     })
 
     describe('#getExAddresses()', () => {
-      it('should return array', () => {
-        expect(tl1.exchange.getExAddresses()).to.eventually.be.an('array')
+      it('should return array', async () => {
+        await expect(tl1.exchange.getExAddresses()).to.eventually.be.an('array')
       })
     })
 
     describe('#getOrderbook()', () => {
-      it('should return orderbook', () => {
-        expect(
+      it('should return orderbook', async () => {
+        await expect(
           tl1.exchange.getOrderbook(makerTokenAddress, takerTokenAddress)
         ).to.eventually.have.keys('asks', 'bids')
       })
@@ -217,8 +217,10 @@ describe('e2e', () => {
         )
       })
 
-      it('should prepare a fill order tx for latest order', () => {
-        expect(tl2.exchange.prepTakeOrder(order, 1)).to.eventually.have.keys(
+      it('should prepare a fill order tx for latest order', async () => {
+        await expect(
+          tl2.exchange.prepTakeOrder(order, 1)
+        ).to.eventually.have.keys(
           'rawTx',
           'ethFees',
           'makerMaxFees',

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -249,7 +249,7 @@ describe('e2e', () => {
         it('should prepare tx for eth transfer', async () => {
           await expect(
             tl1.payment.prepareEth(user2.address, 0.05)
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
       })
 

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -221,8 +221,10 @@ describe('e2e', () => {
           await wait()
         })
 
-        it('should return transfers array', () => {
-          expect(tl1.payment.get(network.address)).to.eventually.be.an('array')
+        it('should return transfers array', async () => {
+          await expect(tl1.payment.get(network.address)).to.eventually.be.an(
+            'array'
+          )
         })
 
         it('should return latest transfer', async () => {
@@ -244,8 +246,8 @@ describe('e2e', () => {
       })
 
       describe('#prepareEth()', () => {
-        it('should prepare tx for eth transfer', () => {
-          expect(
+        it('should prepare tx for eth transfer', async () => {
+          await expect(
             tl1.payment.prepareEth(user2.address, 0.05)
           ).to.eventually.have.keys('rawTx', 'ethFees')
         })

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -75,7 +75,7 @@ describe('e2e', () => {
               2000,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
 
         it('should prepare raw trustline update request tx in network with DEFAULT interest rates', async () => {
@@ -86,7 +86,7 @@ describe('e2e', () => {
               2000,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
 
         it('should prepare raw trustline update request tx in network with CUSTOM interest rates', async () => {
@@ -102,7 +102,7 @@ describe('e2e', () => {
                 isFrozen: false
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
 
         it('should prepare raw trustline update request tx with freezing', async () => {
@@ -118,7 +118,7 @@ describe('e2e', () => {
                 isFrozen: true
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
       })
 
@@ -430,7 +430,7 @@ describe('e2e', () => {
               1250,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
 
         it('should prepare accept tx for network with DEFAULT interest rates', async () => {
@@ -441,7 +441,7 @@ describe('e2e', () => {
               1250,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
 
         it('should prepare accept tx for network with CUSTOM interest rates', () => {
@@ -457,7 +457,7 @@ describe('e2e', () => {
                 isFrozen: false
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
 
         it('should prepare accept tx for trustline update with freezing', async () => {
@@ -473,7 +473,7 @@ describe('e2e', () => {
                 isFrozen: true
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
         })
       })
 

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -66,9 +66,9 @@ describe('e2e', () => {
         await wait()
       })
 
-      describe('#prepareUpdate()', () => {
-        it('should prepare raw trustline update request tx in network WITHOUT interest rates', () => {
-          expect(
+      describe('#prepareUpdate()', async () => {
+        it('should prepare raw trustline update request tx in network WITHOUT interest rates', async () => {
+          await expect(
             tl1.trustline.prepareUpdate(
               networkWithoutInterestRates.address,
               user2.address,
@@ -78,8 +78,8 @@ describe('e2e', () => {
           ).to.eventually.have.keys('rawTx', 'ethFees')
         })
 
-        it('should prepare raw trustline update request tx in network with DEFAULT interest rates', () => {
-          expect(
+        it('should prepare raw trustline update request tx in network with DEFAULT interest rates', async () => {
+          await expect(
             tl1.trustline.prepareUpdate(
               networkDefaultInterestRates.address,
               user2.address,
@@ -89,8 +89,8 @@ describe('e2e', () => {
           ).to.eventually.have.keys('rawTx', 'ethFees')
         })
 
-        it('should prepare raw trustline update request tx in network with CUSTOM interest rates', () => {
-          expect(
+        it('should prepare raw trustline update request tx in network with CUSTOM interest rates', async () => {
+          await expect(
             tl1.trustline.prepareUpdate(
               networkCustomInterestRates.address,
               user2.address,
@@ -105,8 +105,8 @@ describe('e2e', () => {
           ).to.eventually.have.keys('rawTx', 'ethFees')
         })
 
-        it('should prepare raw trustline update request tx with freezing', () => {
-          expect(
+        it('should prepare raw trustline update request tx with freezing', async () => {
+          await expect(
             tl1.trustline.prepareUpdate(
               networkCustomInterestRates.address,
               user2.address,
@@ -135,7 +135,7 @@ describe('e2e', () => {
             2000,
             1000
           )
-          expect(
+          await expect(
             tl1.trustline.confirm(txWithoutInterestRates.rawTx)
           ).to.eventually.be.a('string')
         })
@@ -147,7 +147,7 @@ describe('e2e', () => {
             2000,
             1000
           )
-          expect(
+          await expect(
             tl1.trustline.confirm(txDefaultInterestRates.rawTx)
           ).to.eventually.be.a('string')
         })
@@ -164,7 +164,7 @@ describe('e2e', () => {
               isFrozen: false
             }
           )
-          expect(
+          await expect(
             tl1.trustline.confirm(txCustomInterestRates.rawTx)
           ).to.eventually.be.a('string')
         })
@@ -181,9 +181,9 @@ describe('e2e', () => {
               isFrozen: true
             }
           )
-          expect(tl1.trustline.confirm(txFreezing.rawTx)).to.eventually.be.a(
-            'string'
-          )
+          await expect(
+            tl1.trustline.confirm(txFreezing.rawTx)
+          ).to.eventually.be.a('string')
         })
       })
 
@@ -422,8 +422,8 @@ describe('e2e', () => {
       })
 
       describe('#prepareAccept()', () => {
-        it('should prepare accept tx for network WITHOUT interest rates', () => {
-          expect(
+        it('should prepare accept tx for network WITHOUT interest rates', async () => {
+          await expect(
             tl2.trustline.prepareAccept(
               networkWithoutInterestRates.address,
               user1.address,
@@ -433,8 +433,8 @@ describe('e2e', () => {
           ).to.eventually.have.keys('rawTx', 'ethFees')
         })
 
-        it('should prepare accept tx for network with DEFAULT interest rates', () => {
-          expect(
+        it('should prepare accept tx for network with DEFAULT interest rates', async () => {
+          await expect(
             tl2.trustline.prepareAccept(
               networkDefaultInterestRates.address,
               user1.address,
@@ -461,7 +461,7 @@ describe('e2e', () => {
         })
 
         it('should prepare accept tx for trustline update with freezing', async () => {
-          expect(
+          await expect(
             tl2.trustline.prepareAccept(
               networkCustomInterestRates.address,
               user1.address,
@@ -826,8 +826,8 @@ describe('e2e', () => {
       })
 
       describe('#getAll()', () => {
-        it('should return array of trustlines', () => {
-          expect(
+        it('should return array of trustlines', async () => {
+          await expect(
             tl1.trustline.getAll(networkWithoutInterestRates.address)
           ).to.eventually.be.an('array')
         })

--- a/tests/e2e/User.test.ts
+++ b/tests/e2e/User.test.ts
@@ -64,9 +64,9 @@ describe('e2e', () => {
         })
       })
 
-      describe('#requestEth()', () => {
-        it('should not send eth to existing user', () => {
-          expect(tlExisting.user.requestEth()).to.eventually.equal(null)
+      describe('#requestEth()', async () => {
+        it('should not send eth to existing user', async () => {
+          await expect(tlExisting.user.requestEth()).to.eventually.equal(null)
         })
 
         it('should send eth to new user', async () => {

--- a/tests/integration/User.test.ts
+++ b/tests/integration/User.test.ts
@@ -40,14 +40,18 @@ describe('integration', () => {
     })
 
     describe('#exportPrivateKey()', () => {
-      it('should show private key of user', () => {
-        expect(tlExisting.user.exportPrivateKey()).to.eventually.be.a('string')
+      it('should show private key of user', async () => {
+        await expect(tlExisting.user.exportPrivateKey()).to.eventually.be.a(
+          'string'
+        )
       })
     })
 
     describe('#showSeed()', () => {
-      it('should show seed of loaded user', () => {
-        expect(tlExisting.user.showSeed()).to.eventually.eq(USER_1.mnemonic)
+      it('should show seed of loaded user', async () => {
+        await expect(tlExisting.user.showSeed()).to.eventually.eq(
+          USER_1.mnemonic
+        )
       })
     })
 


### PR DESCRIPTION
This fixes test functions using promises, but not waiting for their
result.

We did run into multiple 'UnhandledPromiseRejectionWarning:
AssertionError' errors. Though the test runner did log them, it
ignored them while reporting the result of the tests.

This is bad, since it will hide actual errors in the tests.

Instead of something like:

,----
| it('should return all user addresses of specific currency network', () => {
|   expect(
|     currencyNetwork.getUsers(networks[0].address)
|   ).to.eventually.be.an('array')
| })
`----

we must make the inner function async and await the expect value:

,----
| it('should return all user addresses of specific currency network', async () => {
|   await expect(
|     currencyNetwork.getUsers(networks[0].address)
|   ).to.eventually.be.an('array')
| })
`----

This fixes all occurences that use's chai's `eventually` [1].

See https://github.com/trustlines-protocol/clientlib/issues/280

[1] https://www.chaijs.com/plugins/chai-as-promised/
