### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.nyc_output
+.git
+tests/e2e-config/addresses.json


### PR DESCRIPTION
The build context could get rather large before. Let's remove stuff we
know we don't need.