### PR TITLE
Add method to get cancelled trustline update events

### DIFF
--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -16,6 +16,7 @@ import {
   EventFilterOptions,
   FeePayer,
   isFeePayerValue,
+  NetworkEvent,
   NetworkTrustlineEvent,
   PaymentOptions,
   RawTxObject,
@@ -284,6 +285,21 @@ export class Trustline {
     return this.event.get<NetworkTrustlineEvent>(networkAddress, {
       ...filter,
       type: 'TrustlineUpdateRequest'
+    })
+  }
+
+  /**
+   * Returns trustline update cancels of loaded user in a currency network.
+   * @param networkAddress Address of a currency network.
+   * @param filter Event filter object. See `EventFilterOptions` for more information.
+   */
+  public getCancels(
+    networkAddress: string,
+    filter: EventFilterOptions = {}
+  ): Promise<NetworkEvent[]> {
+    return this.event.get<NetworkEvent>(networkAddress, {
+      ...filter,
+      type: 'TrustlineUpdateCancel'
     })
   }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -147,10 +147,17 @@ export interface NetworkTrustlineEvent extends NetworkEvent {
   isFrozen: boolean
 }
 
-export type AnyNetworkEvent = NetworkTransferEvent | NetworkTrustlineEvent
+export type NetworkTrustlineCancelEventRaw = NetworkEvent
+export type NetworkTrustlineCancelEvent = NetworkEvent
+
+export type AnyNetworkEvent =
+  | NetworkTransferEvent
+  | NetworkTrustlineEvent
+  | NetworkTrustlineCancelEvent
 export type AnyNetworkEventRaw =
   | NetworkTransferEventRaw
   | NetworkTrustlineEventRaw
+  | NetworkTrustlineCancelEventRaw
 
 export interface TokenEvent extends TLEvent {
   tokenAddress: string

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -357,6 +357,21 @@ export const FAKE_TRUSTLINE_UPDATE_EVENT = {
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
 }
 
+export const FAKE_TRUSTLINE_CANCEL_EVENT = {
+  blockNumber: 123,
+  counterParty: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
+  direction: 'sent',
+  from: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
+  networkAddress: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
+  status: 'pending',
+  timestamp: 123456789,
+  to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
+  transactionId:
+    '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
+  type: 'TrustlineUpdateCancel',
+  user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
+}
+
 export const FAKE_TOKEN_EVENT = {
   amount: '150',
   blockNumber: 123,

--- a/tests/helpers/FakeEvent.ts
+++ b/tests/helpers/FakeEvent.ts
@@ -1,6 +1,7 @@
 import { Event } from '../../src/Event'
 
 import {
+  FAKE_TRUSTLINE_CANCEL_EVENT,
   FAKE_TRUSTLINE_UPDATE_EVENT,
   FAKE_TRUSTLINE_UPDATE_REQUEST_EVENT
 } from '../Fixtures'
@@ -20,6 +21,8 @@ export class FakeEvent extends Event {
         return [FAKE_TRUSTLINE_UPDATE_REQUEST_EVENT]
       case 'TrustlineUpdate':
         return [FAKE_TRUSTLINE_UPDATE_EVENT]
+      case 'TrustlineUpdateCancel':
+        return [FAKE_TRUSTLINE_CANCEL_EVENT]
       default:
         return []
     }

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -132,6 +132,18 @@ describe('unit', () => {
       })
     })
 
+    describe('#prepareCancelTrustlineUpdate()', () => {
+      beforeEach(() => init())
+
+      it('should return a transaction object', async () => {
+        const tx = await trustline.prepareCancelTrustlineUpdate(
+          FAKE_NETWORK.address,
+          '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18'
+        )
+        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
+      })
+    })
+
     describe('#confirm()', () => {
       beforeEach(() => init())
 
@@ -204,11 +216,11 @@ describe('unit', () => {
       })
     })
 
-    describe('#getCancels()', () => {
+    describe('#getTrustlineUpdateCancels()', () => {
       beforeEach(() => init())
 
       it('should return mocked TrustlineUpdateCancel events', async () => {
-        const [updateRequestEvent] = await trustline.getCancels(
+        const [updateRequestEvent] = await trustline.getTrustlineUpdateCancels(
           FAKE_NETWORK.address
         )
         assert.equal(updateRequestEvent.type, 'TrustlineUpdateCancel')

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -204,6 +204,17 @@ describe('unit', () => {
       })
     })
 
+    describe('#getCancels()', () => {
+      beforeEach(() => init())
+
+      it('should return mocked TrustlineUpdateCancel events', async () => {
+        const [updateRequestEvent] = await trustline.getCancels(
+          FAKE_NETWORK.address
+        )
+        assert.equal(updateRequestEvent.type, 'TrustlineUpdateCancel')
+      })
+    })
+
     describe('#getUpdates()', () => {
       beforeEach(() => init())
 


### PR DESCRIPTION
Add method to cancel trustline updates.

I did not implement a function to get not cancelled update events as it requires quite a bit of processing of events that the clientlib should not do and it is not really useful. The important information one wants to get out of the clientlib would be a list of pending trustline updates and the `getRequests()` function was not providing this information.

closes https://github.com/trustlines-protocol/clientlib/issues/283 https://github.com/trustlines-protocol/clientlib/issues/284