### PR TITLE
Make createLink synchronious

### DIFF
--- a/src/User.ts
+++ b/src/User.ts
@@ -189,10 +189,7 @@ export class User {
    * @param username Custom username.
    * @param customBase Optional custom base for link. Default `trustlines://`.
    */
-  public async createLink(
-    username: string,
-    customBase?: string
-  ): Promise<string> {
+  public createLink(username: string, customBase?: string): string {
     const params = ['contact', this.address, username]
     return utils.createLink(params, customBase)
   }

--- a/tests/unit/User.test.ts
+++ b/tests/unit/User.test.ts
@@ -195,7 +195,7 @@ describe('unit', () => {
       const username = 'testname'
 
       it('should create trustlines:// link', async () => {
-        const contactLink = await user.createLink(username)
+        const contactLink = user.createLink(username)
         assert.equal(
           contactLink,
           `trustlines://contact/${user.address}/${username}`
@@ -203,10 +203,7 @@ describe('unit', () => {
       })
 
       it('should create custom link', async () => {
-        const contactLink = await user.createLink(
-          username,
-          'http://custom.network'
-        )
+        const contactLink = user.createLink(username, 'http://custom.network')
         assert.equal(
           contactLink,
           `http://custom.network/contact/${user.address}/${username}`


### PR DESCRIPTION
There is no need for createLink to be async. Changing to a synchronous function.

fixes #286