### PR TITLE
Make contact.createLink synchronous

### DIFF
--- a/src/Contact.ts
+++ b/src/Contact.ts
@@ -23,11 +23,11 @@ export class Contact {
    * @param username Name of contact to share.
    * @param customBase Optional custom base for link. Default `trustlines://`.
    */
-  public async createLink(
+  public createLink(
     address: string,
     username: string,
     customBase?: string
-  ): Promise<string> {
+  ): string {
     const params = ['contact', address, username]
     return utils.createLink(params, customBase)
   }

--- a/tests/unit/Contact.test.ts
+++ b/tests/unit/Contact.test.ts
@@ -1,0 +1,75 @@
+import chai from 'chai'
+import 'mocha'
+
+import { Contact } from '../../src/Contact'
+import { User } from '../../src/User'
+
+import { FakeTLProvider } from '../helpers/FakeTLProvider'
+import { FakeTLSigner } from '../helpers/FakeTLSigner'
+import { FakeTLWallet } from '../helpers/FakeTLWallet'
+
+import { FAKE_USER_ADDRESSES } from '../Fixtures'
+
+const { assert } = chai
+
+describe('unit', () => {
+  describe('Contact', () => {
+    // Test object
+    let user: User
+    let contact: Contact
+
+    // Mocked classes
+    let fakeTLProvider
+    let fakeTLWallet
+    let fakeTLSigner
+
+    const init = () => {
+      fakeTLProvider = new FakeTLProvider()
+      fakeTLWallet = new FakeTLWallet()
+      fakeTLSigner = new FakeTLSigner()
+      user = new User({
+        provider: fakeTLProvider,
+        signer: fakeTLSigner,
+        wallet: fakeTLWallet
+      })
+
+      const params = { user, provider: fakeTLProvider }
+      contact = new Contact(params)
+    }
+
+    describe('#constructor()', () => {
+      beforeEach(() => init())
+
+      it('should construct a Contact instance', () => {
+        assert.propertyVal(contact, 'user', user)
+        assert.propertyVal(contact, 'provider', fakeTLProvider)
+      })
+    })
+
+    describe('#createLink()', () => {
+      beforeEach(() => init())
+
+      const username = 'testname'
+
+      it('should create trustlines:// link', async () => {
+        const contactLink = contact.createLink(FAKE_USER_ADDRESSES[0], username)
+        assert.equal(
+          contactLink,
+          `trustlines://contact/${FAKE_USER_ADDRESSES[0]}/${username}`
+        )
+      })
+
+      it('should create custom link', async () => {
+        const contactLink = contact.createLink(
+          FAKE_USER_ADDRESSES[0],
+          username,
+          'http://custom.network'
+        )
+        assert.equal(
+          contactLink,
+          `http://custom.network/contact/${FAKE_USER_ADDRESSES[0]}/${username}`
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
utils.createLink is synchronous, so there is no point in contact.createLink to by async.

I missed the createLink function on the contact object in my previous PR #287