### PR TITLE
Add function to get accured interests for user

### DIFF
--- a/src/Information.ts
+++ b/src/Information.ts
@@ -63,6 +63,35 @@ export class Information {
     )
   }
 
+  public async getTrustlineAccruedInterests(
+    networkAddress: string,
+    counterpartyAddress: string,
+    options: {
+      timeWindowOption?: { startTime: number; endTime: number }
+      decimalsOptions?: DecimalsOptions
+    } = {}
+  ): Promise<TrustlineAccruedInterestsObject> {
+    const baseUrl = `networks/${networkAddress}/users/${await this.user.getAddress()}/interests/${counterpartyAddress}`
+    const parameterUrl = utils.buildUrl(baseUrl, options.timeWindowOption || {})
+
+    const [
+      trustlineAccruedInterestsRaw,
+      { networkDecimals, interestRateDecimals }
+    ] = await Promise.all([
+      this.provider.fetchEndpoint<TrustlineAccruedInterestsRaw>(parameterUrl),
+      this.currencyNetwork.getDecimals(
+        networkAddress,
+        options.decimalsOptions || {}
+      )
+    ])
+
+    return this.formatTrustlineAccruedInterestsRaw(
+      trustlineAccruedInterestsRaw,
+      networkDecimals,
+      interestRateDecimals
+    )
+  }
+
   private formatTrustlineAccruedInterestsRaw(
     trustlineAccruedInterestsRaw: TrustlineAccruedInterestsRaw,
     networkDecimals: number,

--- a/src/Information.ts
+++ b/src/Information.ts
@@ -1,0 +1,99 @@
+import { TLProvider } from './providers/TLProvider'
+import { User } from './User'
+
+import utils from './utils'
+
+import {
+  AccruedInterestsObject,
+  AccruedInterestsRaw,
+  DecimalsOptions,
+  TrustlineAccruedInterestsObject,
+  TrustlineAccruedInterestsRaw,
+  UserAccruedInterestsObject,
+  UserAccruedInterestsRaw
+} from './typings'
+
+import { CurrencyNetwork } from './CurrencyNetwork'
+
+/**
+ * The Information class contains all methods related to retrieving processed infos about a user's trustlines.
+ */
+export class Information {
+  private provider: TLProvider
+  private user: User
+  private currencyNetwork: CurrencyNetwork
+
+  constructor(params: {
+    user: User
+    provider: TLProvider
+    currencyNetwork: CurrencyNetwork
+  }) {
+    this.user = params.user
+    this.provider = params.provider
+    this.currencyNetwork = params.currencyNetwork
+  }
+
+  public async getUserAccruedInterests(
+    networkAddress: string,
+    options: {
+      timeWindowOption?: { startTime: number; endTime: number }
+      decimalsOptions?: DecimalsOptions
+    } = {}
+  ): Promise<UserAccruedInterestsObject> {
+    const baseUrl = `networks/${networkAddress}/users/${await this.user.getAddress()}/interests`
+    const parameterUrl = utils.buildUrl(baseUrl, options.timeWindowOption || {})
+
+    const [
+      userAccruedInterests,
+      { networkDecimals, interestRateDecimals }
+    ] = await Promise.all([
+      this.provider.fetchEndpoint<UserAccruedInterestsRaw>(parameterUrl),
+      this.currencyNetwork.getDecimals(
+        networkAddress,
+        options.decimalsOptions || {}
+      )
+    ])
+
+    return userAccruedInterests.map(trustlineAccruedInterestsRaw =>
+      this.formatTrustlineAccruedInterestsRaw(
+        trustlineAccruedInterestsRaw,
+        networkDecimals,
+        interestRateDecimals
+      )
+    )
+  }
+
+  private formatTrustlineAccruedInterestsRaw(
+    trustlineAccruedInterestsRaw: TrustlineAccruedInterestsRaw,
+    networkDecimals: number,
+    interestRateDecimals: number
+  ): TrustlineAccruedInterestsObject {
+    return {
+      accruedInterests: trustlineAccruedInterestsRaw.accruedInterests.map(
+        accruedInterests =>
+          this.formatAccruedInterestsRaw(
+            accruedInterests,
+            networkDecimals,
+            interestRateDecimals
+          )
+      ),
+      user: trustlineAccruedInterestsRaw.user,
+      counterparty: trustlineAccruedInterestsRaw.counterparty
+    }
+  }
+
+  private formatAccruedInterestsRaw(
+    accruedInterests: AccruedInterestsRaw,
+    networkDecimals: number,
+    interestRateDecimals: number
+  ): AccruedInterestsObject {
+    return {
+      value: utils.formatToAmount(accruedInterests.value, networkDecimals),
+      interestRate: utils.formatToAmount(
+        accruedInterests.interestRate,
+        interestRateDecimals
+      ),
+      timestamp: accruedInterests.timestamp
+    }
+  }
+}

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -545,6 +545,35 @@ export interface CloseTxObject extends TxObject {
   maxFees: Amount
 }
 
+// INFORMATIONS
+
+export interface AccruedInterestsRaw {
+  value: string
+  interestRate: string
+  timestamp: number
+}
+
+export interface AccruedInterestsObject {
+  value: Amount
+  interestRate: Amount
+  timestamp: number
+}
+
+export interface TrustlineAccruedInterestsRaw {
+  accruedInterests: AccruedInterestsRaw[]
+  user: string
+  counterparty: string
+}
+
+export interface TrustlineAccruedInterestsObject {
+  accruedInterests: AccruedInterestsObject[]
+  user: string
+  counterparty: string
+}
+
+export type UserAccruedInterestsRaw = TrustlineAccruedInterestsRaw[]
+export type UserAccruedInterestsObject = TrustlineAccruedInterestsObject[]
+
 // EXCHANGE
 export interface Order {
   maker: string // this.user.address

--- a/tests/e2e/Information.test.ts
+++ b/tests/e2e/Information.test.ts
@@ -1,0 +1,125 @@
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import 'mocha'
+
+import { TLNetwork } from '../../src/TLNetwork'
+import {
+  AnyNetworkEvent,
+  ExchangeCancelEvent,
+  ExchangeFillEvent,
+  NetworkDetails,
+  NetworkTransferEvent,
+  NetworkTrustlineEvent,
+  TokenAmountEvent,
+  UserAccruedInterestsObject
+} from '../../src/typings'
+
+import {
+  createAndLoadUsers,
+  deployIdentities,
+  extraData,
+  requestEth,
+  setTrustlines,
+  tlNetworkConfig,
+  wait
+} from '../Fixtures'
+
+import { Information } from '../../src/Information'
+
+chai.use(chaiAsPromised)
+
+describe('e2e', () => {
+  describe(`Information`, () => {
+    const { expect } = chai
+
+    const tl1 = new TLNetwork(tlNetworkConfig)
+    const tl2 = new TLNetwork(tlNetworkConfig)
+    let user1
+    let user2
+    let network
+    let information
+
+    describe('#getUserAccruedInterests()', () => {
+      before(async () => {
+        ;[network] = await tl1.currencyNetwork.getAll()
+        // create new users
+        ;[user1, user2] = await createAndLoadUsers([tl1, tl2])
+        information = new Information({
+          user: tl1.user,
+          currencyNetwork: tl1.currencyNetwork,
+          provider: tl1.provider
+        })
+        await deployIdentities([tl1, tl2])
+        // request ETH
+        await requestEth([tl1, tl2])
+        // set trustline with high interest rates
+        const updateTxUser1 = await tl1.trustline.prepareUpdate(
+          network.address,
+          user2.address,
+          2000,
+          2000,
+          {
+            interestRateGiven: 300,
+            interestRateReceived: 300
+          }
+        )
+        await tl1.trustline.confirm(updateTxUser1.rawTx)
+        const updateTxUser2 = await tl2.trustline.prepareUpdate(
+          network.address,
+          user1.address,
+          2000,
+          2000,
+          {
+            interestRateGiven: 300,
+            interestRateReceived: 300
+          }
+        )
+        await tl2.trustline.confirm(updateTxUser2.rawTx)
+        await wait()
+
+        // bring imbalance to trustline
+        const transfer1 = await tl1.payment.prepare(
+          network.address,
+          user2.address,
+          1000,
+          { extraData }
+        )
+        await tl1.payment.confirm(transfer1.rawTx)
+        await wait()
+
+        // apply accrued interests to trustline via transfer
+        const transfer2 = await tl2.payment.prepare(
+          network.address,
+          user1.address,
+          1000,
+          { extraData }
+        )
+        await tl2.payment.confirm(transfer2.rawTx)
+        await wait()
+      })
+
+      it('should return list of accrued interests for user', async () => {
+        const userAccruedInterests = await information.getUserAccruedInterests(
+          network.address
+        )
+        expect(userAccruedInterests).to.be.an('Array')
+        expect(userAccruedInterests.length).to.equal(1)
+
+        const trustlineAccruedInterests = userAccruedInterests[0]
+        expect(trustlineAccruedInterests.accruedInterests).to.be.an('Array')
+        expect(trustlineAccruedInterests.accruedInterests.length).to.equal(1)
+        expect(trustlineAccruedInterests.user).to.equal(user1.address)
+        expect(trustlineAccruedInterests.counterparty).to.equal(user2.address)
+
+        const accruedInterest = trustlineAccruedInterests.accruedInterests[0]
+        expect(accruedInterest.value).to.have.keys('raw', 'value', 'decimals')
+        expect(accruedInterest.interestRate).to.have.keys(
+          'raw',
+          'value',
+          'decimals'
+        )
+        expect(accruedInterest.timestamp).to.be.a('number')
+      })
+    })
+  })
+})

--- a/tests/e2e/Information.test.ts
+++ b/tests/e2e/Information.test.ts
@@ -3,16 +3,6 @@ import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'
-import {
-  AnyNetworkEvent,
-  ExchangeCancelEvent,
-  ExchangeFillEvent,
-  NetworkDetails,
-  NetworkTransferEvent,
-  NetworkTrustlineEvent,
-  TokenAmountEvent,
-  UserAccruedInterestsObject
-} from '../../src/typings'
 
 import {
   createAndLoadUsers,
@@ -106,6 +96,27 @@ describe('e2e', () => {
         expect(userAccruedInterests.length).to.equal(1)
 
         const trustlineAccruedInterests = userAccruedInterests[0]
+        expect(trustlineAccruedInterests.accruedInterests).to.be.an('Array')
+        expect(trustlineAccruedInterests.accruedInterests.length).to.equal(1)
+        expect(trustlineAccruedInterests.user).to.equal(user1.address)
+        expect(trustlineAccruedInterests.counterparty).to.equal(user2.address)
+
+        const accruedInterest = trustlineAccruedInterests.accruedInterests[0]
+        expect(accruedInterest.value).to.have.keys('raw', 'value', 'decimals')
+        expect(accruedInterest.interestRate).to.have.keys(
+          'raw',
+          'value',
+          'decimals'
+        )
+        expect(accruedInterest.timestamp).to.be.a('number')
+      })
+
+      it('should return list of accrued interests for trustline', async () => {
+        const trustlineAccruedInterests = await information.getTrustlineAccruedInterests(
+          network.address,
+          user2.address
+        )
+
         expect(trustlineAccruedInterests.accruedInterests).to.be.an('Array')
         expect(trustlineAccruedInterests.accruedInterests.length).to.equal(1)
         expect(trustlineAccruedInterests.user).to.equal(user1.address)


### PR DESCRIPTION
closes https://github.com/trustlines-protocol/clientlib/issues/291
the e2e tests will fail until this is merged: https://github.com/trustlines-protocol/relay/pull/378

I created a new class `Information` because I did not feel like the method to get interests would fit somewhere else and other methods related to providing processed informations will be added later.