### PR TITLE
Enable ws stream subscribers to handle ws errors

### DIFF
--- a/src/Event.ts
+++ b/src/Event.ts
@@ -14,7 +14,8 @@ import {
   AnyNetworkEventRaw,
   AnyTokenEventRaw,
   DecimalsOptions,
-  EventFilterOptions
+  EventFilterOptions,
+  ReconnectingWSOptions
 } from './typings'
 
 const CURRENCY_NETWORK = 'CurrencyNetwork'
@@ -91,13 +92,20 @@ export class Event {
   /**
    * @hidden
    */
-  public updateStream(): Observable<any> {
+  public updateStream(
+    reconnectingOptions?: ReconnectingWSOptions
+  ): Observable<any> {
     return fromPromise(this.user.getAddress()).flatMap(userAddress =>
       this.provider
-        .createWebsocketStream('streams/events', 'subscribe', {
-          event: 'all',
-          user: userAddress
-        })
+        .createWebsocketStream(
+          'streams/events',
+          'subscribe',
+          {
+            event: 'all',
+            user: userAddress
+          },
+          reconnectingOptions
+        )
         .mergeMap(event => {
           if (event.hasOwnProperty('networkAddress')) {
             return this.currencyNetwork

--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -10,6 +10,7 @@ import utils from './utils'
 import {
   DecimalsOptions,
   PaymentRequestMessage,
+  ReconnectingWSOptions,
   UsernameMessage
 } from './typings'
 
@@ -81,13 +82,20 @@ export class Messaging {
   /**
    * Returns a websocket observable that can be subscribed to.
    */
-  public messageStream(): Observable<any> {
+  public messageStream(
+    reconnectingOptions?: ReconnectingWSOptions
+  ): Observable<any> {
     return fromPromise(this.user.getAddress()).flatMap(userAddress =>
       this.provider
-        .createWebsocketStream(`/streams/messages`, 'listen', {
-          type: 'all',
-          user: userAddress
-        })
+        .createWebsocketStream(
+          `/streams/messages`,
+          'listen',
+          {
+            type: 'all',
+            user: userAddress
+          },
+          reconnectingOptions
+        )
         .mergeMap(data => {
           if (data.type) {
             return [data]

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -10,7 +10,7 @@ import {
   Amount,
   MetaTransaction,
   MetaTransactionFees,
-  NetworkDetailsRaw,
+  ReconnectingWSOptions,
   TxInfos,
   TxInfosRaw
 } from '../typings'
@@ -51,17 +51,20 @@ export class RelayProvider implements TLProvider {
    * @param endpoint Websocket stream endpoint to connect to.
    * @param functionName Function to call on connection.
    * @param args Function arguments.
+   * @param reconnectOnError Optional flag whether to try reconnecting web socket.
    */
   public createWebsocketStream(
     endpoint: string,
     functionName: string,
-    args: object
+    args: object,
+    reconnectingOptions?: ReconnectingWSOptions
   ): Observable<any> {
     const trimmedEndpoint = utils.trimUrl(endpoint)
     return utils.websocketStream(
       `${this.relayWsApiUrl}/${trimmedEndpoint}`,
       functionName,
-      args
+      args,
+      reconnectingOptions
     )
   }
 

--- a/src/providers/TLProvider.ts
+++ b/src/providers/TLProvider.ts
@@ -2,6 +2,7 @@ import {
   Amount,
   MetaTransaction,
   MetaTransactionFees,
+  ReconnectingWSOptions,
   TxInfos
 } from '../typings'
 
@@ -17,7 +18,8 @@ export interface TLProvider {
   createWebsocketStream(
     endpoint: string,
     functionName: string,
-    args: object
+    args: object,
+    reconnectingOptions?: ReconnectingWSOptions
   ): any
   getTxInfos(userAddress: string): Promise<TxInfos>
   getMetaTxInfos(userAddress: string): Promise<TxInfos>

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { ethers } from 'ethers'
+import { Options as ReconnectingOptions } from 'reconnecting-websocket'
 
 /**
  * Configuration object for a TLNetwork instance
@@ -699,4 +700,8 @@ export interface OrdersQuery {
   maker?: string
   taker?: string
   feeRecipient?: string
+}
+
+export type ReconnectingWSOptions = ReconnectingOptions & {
+  reconnectOnError?: boolean
 }

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -19,8 +19,7 @@ import {
   Amount,
   MetaTransaction,
   MetaTransactionFees,
-  NetworkDetailsRaw,
-  RawTxObject,
+  ReconnectingWSOptions,
   TxInfos
 } from '../../src/typings'
 
@@ -126,7 +125,8 @@ export class FakeTLProvider implements TLProvider {
   public createWebsocketStream(
     endpoint: string,
     functionName: string,
-    args: object
+    args: object,
+    reconnectingOptions?: ReconnectingWSOptions
   ) {
     throw new Error('Method not implemented.')
   }

--- a/tests/unit/Utils.test.ts
+++ b/tests/unit/Utils.test.ts
@@ -1,14 +1,12 @@
 import BigNumber from 'bignumber.js'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { ethers } from 'ethers'
 import fetchMock = require('fetch-mock')
 import 'mocha'
 
 import utils from '../../src/utils'
 
 import { ExchangeCancelEvent, ExchangeFillEvent } from '../../src/typings'
-import { USER_1_ETHERS_WALLET_V1, USER_1_IDENTITY_WALLET_V1 } from '../Fixtures'
 
 chai.use(chaiAsPromised)
 const { assert } = chai


### PR DESCRIPTION
Related to https://github.com/trustlines-network/mobileapp/issues/880.
We basically want to be able to show in the app that it is not connected to a relay server.

It was not possible to handle ws errors when using the clientlib.
Even though the clientlib handles the reconnection via
[reconnecting-websocket](https://github.com/pladaria/reconnecting-websocket),
one could not know or handle that the ws connection got closed.

It is now possible to pass in options for the reconnection or even
disable it via `reconnectOnError: false`.
It is also possible to detect that a ws connection errored while the
clientlib handles the reconnection.