### PR TITLE
Feature/get all trustlines of user

### DIFF
--- a/src/CurrencyNetwork.ts
+++ b/src/CurrencyNetwork.ts
@@ -200,7 +200,6 @@ export class CurrencyNetwork {
           typeof decimalsCache[networkAddress].networkDecimals !== 'number' ||
           typeof decimalsCache[networkAddress].interestRateDecimals !== 'number'
         ) {
-          console.log('FETCHED decimals...')
           const fetchedDecimals = await this.getInfo(networkAddress)
 
           if (
@@ -217,8 +216,6 @@ export class CurrencyNetwork {
             decimalsCache[networkAddress].interestRateDecimals =
               fetchedDecimals.interestRateDecimals
           }
-        } else {
-          console.log('CACHED decimals...')
         }
 
         return decimalsCache[networkAddress]

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -260,6 +260,29 @@ export class Trustline {
   }
 
   /**
+   * Returns all trustlines of a loaded user in all currency networks.
+   */
+  public async getAllOfUser(): Promise<TrustlineObject[]> {
+    const endpoint = `users/${await this.user.getAddress()}/trustlines`
+    const trustlines = await this.provider.fetchEndpoint<TrustlineRaw[]>(
+      endpoint
+    )
+    const networkAddressesOfTrustlines = new Set(
+      trustlines.map(trustline => trustline.currencyNetwork)
+    )
+    const decimalsMap = await this.currencyNetwork.getDecimalsMap(
+      Array.from(networkAddressesOfTrustlines)
+    )
+    return trustlines.map(trustline =>
+      this._formatTrustline(
+        trustline,
+        decimalsMap[trustline.currencyNetwork].networkDecimals,
+        decimalsMap[trustline.currencyNetwork].interestRateDecimals
+      )
+    )
+  }
+
+  /**
    * Returns all trustlines of a loaded user in a currency network.
    * @param networkAddress Address of a currency network.
    * @param options Extra options for user, network or trustline.

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -441,6 +441,10 @@ export interface DecimalsObject {
   interestRateDecimals: number
 }
 
+export interface DecimalsMap {
+  [networkAddress: string]: DecimalsObject
+}
+
 export interface DeployIdentityResponse {
   // The address of the deployed identity contract, as replied by the relay server
   identity: string
@@ -496,6 +500,7 @@ export interface TrustlineObject {
   interestRateGiven: Amount
   interestRateReceived: Amount
   isFrozen: boolean
+  currencyNetwork: string
 }
 
 export interface TrustlineRaw {
@@ -509,6 +514,7 @@ export interface TrustlineRaw {
   interestRateGiven: string
   interestRateReceived: string
   isFrozen: boolean
+  currencyNetwork: string
 }
 
 /**

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -7,6 +7,7 @@ import {
   createAndLoadUsers,
   deployIdentities,
   parametrizedTLNetworkConfig,
+  setTrustlines,
   wait
 } from '../Fixtures'
 
@@ -913,6 +914,37 @@ describe('e2e', () => {
           await expect(
             tl1.trustline.getAll(networkWithoutInterestRates.address)
           ).to.eventually.be.an('array')
+        })
+      })
+
+      describe('#getAllOfUser()', () => {
+        before(async () => {
+          await setTrustlines(
+            networkCustomInterestRates.address,
+            tl3,
+            tl1,
+            1,
+            2
+          )
+          await setTrustlines(
+            networkDefaultInterestRates.address,
+            tl3,
+            tl1,
+            10,
+            20
+          )
+          await setTrustlines(
+            networkWithoutInterestRates.address,
+            tl3,
+            tl1,
+            100,
+            200
+          )
+        })
+
+        it('should return all trustlines across different networks', async () => {
+          const allTrustlines = await tl3.trustline.getAllOfUser()
+          expect(allTrustlines.length).to.equal(3)
         })
       })
 

--- a/tests/helpers/FakeCurrencyNetwork.ts
+++ b/tests/helpers/FakeCurrencyNetwork.ts
@@ -1,5 +1,6 @@
 import { CurrencyNetwork } from '../../src/CurrencyNetwork'
 
+import { TLProvider } from '../../src/providers/TLProvider'
 import { DecimalsObject, NetworkDetails } from '../../src/typings'
 
 import { FAKE_DECIMALS, FAKE_NETWORK } from '../Fixtures'
@@ -10,7 +11,12 @@ import { FAKE_DECIMALS, FAKE_NETWORK } from '../Fixtures'
 export class FakeCurrencyNetwork extends CurrencyNetwork {
   public errors: any = {}
 
-  public async getDecimals(): Promise<DecimalsObject> {
+  constructor(provider: TLProvider) {
+    super(provider)
+    this.getDecimals = this.fakeGetDecimals
+  }
+
+  public async fakeGetDecimals(): Promise<DecimalsObject> {
     if (this.errors.getDecimals) {
       throw new Error('Mocked error in currencyNetwork.getDecimals()!')
     }


### PR DESCRIPTION
Add method for relay REST API `/users/<user_address>/trustlines` to return all trustlines of the requesting user.

I also had to modify the `getDecimals` method for this. Because we are querying trustlines from multiple networks and these networks have different decimals, we somehow have to get these values via `getDecimals`. Previously we were doing the respective call way too often and redundantly. I now added a caching mechanism to the method so that less decimals rest api calls are made. The refactoring is not quite in the context of https://github.com/trustlines-protocol/clientlib/issues/149 and more in the context of making the current usage more efficient.