### PR TITLE
Split providers into messaging and trustlines

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -58,10 +58,18 @@ The user therefore needs some coins ([TLC](https://explore.tlbc.trustlines.found
 
 ```javascript
 const laika = new TLNetwork({
-  protocol: 'https',
-  wsProtocol: 'wss',
-  host: 'relay0.testnet.trustlines.network',
-  path: '/api/v1',
+  relayProviderUrlObject: {
+    protocol: 'https',
+    wsProtocol: 'wss',
+    host: 'relay0.testnet.trustlines.network',
+    path: '/api/v1'
+  },
+  messagingProviderUrlObject: {
+    protocol: 'https',
+    wsProtocol: 'wss',
+    host: 'relay0.testnet.trustlines.network',
+    path: '/api/v1'
+  },
   walletType: 'ethers'
 })
 
@@ -77,10 +85,18 @@ An additional step of deploying the identity contract of the newly created user 
 
 ```javascript
 const laika = new TLNetwork({
-  protocol: 'https',
-  wsProtocol: 'wss',
-  host: 'relay0.testnet.trustlines.network',
-  path: '/api/v1',
+  relayProviderUrlObject: {
+    protocol: 'https',
+    wsProtocol: 'wss',
+    host: 'relay0.testnet.trustlines.network',
+    path: '/api/v1'
+  },
+  messagingProviderUrlObject: {
+    protocol: 'https',
+    wsProtocol: 'wss',
+    host: 'relay0.testnet.trustlines.network',
+    path: '/api/v1'
+  },
   walletType: 'identity',
   identityFactoryAddress: '0x8D2720877Fa796E3C3B91BB91ad6CfcC07Ea249E',
   identityImplementationAddress: '0x8BEe92893D3ec62e5B3EBBe4e536A60Fd9AFc9D7'

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -58,18 +58,8 @@ The user therefore needs some coins ([TLC](https://explore.tlbc.trustlines.found
 
 ```javascript
 const laika = new TLNetwork({
-  relayProviderUrlObject: {
-    protocol: 'https',
-    wsProtocol: 'wss',
-    host: 'relay0.testnet.trustlines.network',
-    path: '/api/v1'
-  },
-  messagingProviderUrlObject: {
-    protocol: 'https',
-    wsProtocol: 'wss',
-    host: 'relay0.testnet.trustlines.network',
-    path: '/api/v1'
-  },
+  relayUrl: 'https://relay0.testnet.trustlines.network/api/v1',
+  messagingUrl: 'https://relay0.testnet.trustlines.network/api/v1',
   walletType: 'ethers'
 })
 
@@ -85,18 +75,8 @@ An additional step of deploying the identity contract of the newly created user 
 
 ```javascript
 const laika = new TLNetwork({
-  relayProviderUrlObject: {
-    protocol: 'https',
-    wsProtocol: 'wss',
-    host: 'relay0.testnet.trustlines.network',
-    path: '/api/v1'
-  },
-  messagingProviderUrlObject: {
-    protocol: 'https',
-    wsProtocol: 'wss',
-    host: 'relay0.testnet.trustlines.network',
-    path: '/api/v1'
-  },
+  relayUrl: 'https://relay0.testnet.trustlines.network/api/v1',
+  messagingUrl: 'https://relay0.testnet.trustlines.network/api/v1',
   walletType: 'identity',
   identityFactoryAddress: '0x8D2720877Fa796E3C3B91BB91ad6CfcC07Ea249E',
   identityImplementationAddress: '0x8BEe92893D3ec62e5B3EBBe4e536A60Fd9AFc9D7'

--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs/Observable'
 import { fromPromise } from 'rxjs/observable/fromPromise'
 
 import { CurrencyNetwork } from './CurrencyNetwork'
-import { TLProvider } from './providers/TLProvider'
+import { Provider } from './providers/Provider'
 import { User } from './User'
 
 import utils from './utils'
@@ -17,11 +17,11 @@ import {
 export class Messaging {
   private user: User
   private currencyNetwork: CurrencyNetwork
-  private provider: TLProvider
+  private provider: Provider
 
   constructor(params: {
     currencyNetwork: CurrencyNetwork
-    provider: TLProvider
+    provider: Provider
     user: User
   }) {
     this.user = params.user

--- a/src/providers/Provider.ts
+++ b/src/providers/Provider.ts
@@ -1,0 +1,67 @@
+import { Observable } from 'rxjs/Observable'
+
+import utils from '../utils'
+
+import { ReconnectingWSOptions } from '../typings'
+
+export class Provider {
+  public ApiUrl: string
+  public WsApiUrl: string
+
+  constructor(ApiUrl: string, WsApiUrl: string) {
+    this.ApiUrl = ApiUrl
+    this.WsApiUrl = WsApiUrl
+  }
+
+  /**
+   * Returns a JSON response from the REST API of the server.
+   * @param endpoint Endpoint to fetch.
+   * @param options Optional fetch options.
+   */
+  public async fetchEndpoint<T>(
+    endpoint: string,
+    options?: object
+  ): Promise<T> {
+    const trimmedEndpoint = utils.trimUrl(endpoint)
+    return utils.fetchUrl<T>(`${this.ApiUrl}/${trimmedEndpoint}`, options)
+  }
+
+  public async postToEndpoint<T>(endpoint: string, data: any): Promise<T> {
+    const options = {
+      body: JSON.stringify(data),
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      method: 'POST'
+    }
+    return this.fetchEndpoint<T>(endpoint, options)
+  }
+
+  /**
+   * Creates a websocket stream connection to the server.
+   * @param endpoint Websocket stream endpoint to connect to.
+   * @param functionName Function to call on connection.
+   * @param args Function arguments.
+   * @param reconnectOnError Optional flag whether to try reconnecting web socket.
+   */
+  public createWebsocketStream(
+    endpoint: string,
+    functionName: string,
+    args: object,
+    reconnectingOptions?: ReconnectingWSOptions
+  ): Observable<any> {
+    const trimmedEndpoint = utils.trimUrl(endpoint)
+    return utils.websocketStream(
+      `${this.WsApiUrl}/${trimmedEndpoint}`,
+      functionName,
+      args,
+      reconnectingOptions
+    )
+  }
+
+  /**
+   * Returns the version of the currently configured provider server.
+   * @returns Version of relay in the format `<name>/vX.X.X`.
+   */
+  public async getVersion(): Promise<string> {
+    return this.fetchEndpoint<string>(`version`)
+  }
+}

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from 'bignumber.js'
 import { ethers } from 'ethers'
-import { Observable } from 'rxjs/Observable'
 
 import utils from '../utils'
 
@@ -10,62 +9,15 @@ import {
   Amount,
   MetaTransaction,
   MetaTransactionFees,
-  ReconnectingWSOptions,
   TxInfos,
   TxInfosRaw
 } from '../typings'
 
-export class RelayProvider implements TLProvider {
-  public relayApiUrl: string
-  public relayWsApiUrl: string
+import { Provider } from './Provider'
 
+export class RelayProvider extends Provider implements TLProvider {
   constructor(relayApiUrl: string, relayWsApiUrl: string) {
-    this.relayApiUrl = relayApiUrl
-    this.relayWsApiUrl = relayWsApiUrl
-  }
-
-  /**
-   * Returns a JSON response from the REST API of the relay server.
-   * @param endpoint Endpoint to fetch.
-   * @param options Optional fetch options.
-   */
-  public async fetchEndpoint<T>(
-    endpoint: string,
-    options?: object
-  ): Promise<T> {
-    const trimmedEndpoint = utils.trimUrl(endpoint)
-    return utils.fetchUrl<T>(`${this.relayApiUrl}/${trimmedEndpoint}`, options)
-  }
-
-  public async postToEndpoint<T>(endpoint: string, data: any): Promise<T> {
-    const options = {
-      body: JSON.stringify(data),
-      headers: new Headers({ 'Content-Type': 'application/json' }),
-      method: 'POST'
-    }
-    return this.fetchEndpoint<T>(endpoint, options)
-  }
-
-  /**
-   * Creates a websocket stream connection to the relay server.
-   * @param endpoint Websocket stream endpoint to connect to.
-   * @param functionName Function to call on connection.
-   * @param args Function arguments.
-   * @param reconnectOnError Optional flag whether to try reconnecting web socket.
-   */
-  public createWebsocketStream(
-    endpoint: string,
-    functionName: string,
-    args: object,
-    reconnectingOptions?: ReconnectingWSOptions
-  ): Observable<any> {
-    const trimmedEndpoint = utils.trimUrl(endpoint)
-    return utils.websocketStream(
-      `${this.relayWsApiUrl}/${trimmedEndpoint}`,
-      functionName,
-      args,
-      reconnectingOptions
-    )
+    super(relayApiUrl, relayWsApiUrl)
   }
 
   /**
@@ -140,14 +92,6 @@ export class RelayProvider implements TLProvider {
   public async getBalance(address: string): Promise<Amount> {
     const balance = await this.fetchEndpoint<string>(`users/${address}/balance`)
     return utils.formatToAmount(balance, 18)
-  }
-
-  /**
-   * Returns the version of the currently configured relay server.
-   * @returns Version of relay in the format `<name>/vX.X.X`.
-   */
-  public async getRelayVersion(): Promise<string> {
-    return this.fetchEndpoint<string>(`version`)
   }
 
   /**

--- a/src/providers/TLProvider.ts
+++ b/src/providers/TLProvider.ts
@@ -11,8 +11,8 @@ import {
  * abstract class of `ethers.js`.
  */
 export interface TLProvider {
-  relayApiUrl: string
-  relayWsApiUrl: string
+  ApiUrl: string
+  WsApiUrl: string
   fetchEndpoint<T>(endpoint: string, options?: object): Promise<T>
   postToEndpoint<T>(endpoint: string, data: any): Promise<T>
   createWebsocketStream(
@@ -25,7 +25,6 @@ export interface TLProvider {
   getMetaTxInfos(userAddress: string): Promise<TxInfos>
   getMetaTxFees(metaTransaction: MetaTransaction): Promise<MetaTransactionFees>
   getBalance(userAddress: string): Promise<Amount>
-  getRelayVersion(): Promise<string>
   sendSignedTransaction(signedTransaction: string): Promise<string>
   sendSignedMetaTransaction(metaTransaction: MetaTransaction): Promise<string>
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -7,37 +7,33 @@ import { Options as ReconnectingOptions } from 'reconnecting-websocket'
  */
 export interface TLNetworkConfig {
   /**
-   * Protocol for communicating with a relay server
+   * Url object for the trustline provider
    */
-  protocol?: string
+  relayProviderUrlObject?: ProviderUrl
   /**
-   * Host of a relay server
+   * Url object for the messaging provider
    */
-  host?: string
-  /**
-   * Port for communication
-   */
-  port?: number
-  /**
-   * Base path for the relay api
-   */
-  path?: string
-  /**
-   * Protocol for WebSockets
-   */
-  wsProtocol?: string
+  messagingProviderUrlObject?: ProviderUrl
   /**
    * Web3 provider
    */
   web3Provider?: any
   /**
-   * Full URL for relay rest api
+   * Full URL for trustline rest api
    */
   relayApiUrl?: string
   /**
-   * Full URL for relay WebSocket api
+   * Full URL for trustline WebSocket api
    */
   relayWsApiUrl?: string
+  /**
+   * Full URL for messaging rest api
+   */
+  messagingApiUrl?: string
+  /**
+   * Full URL for messaging WebSocket api
+   */
+  messagingWsApiUrl?: string
   /**
    * Wallet type to use, either "WalletTypeEthers" or "WalletTypeIdentity".
    */
@@ -54,6 +50,29 @@ export interface TLNetworkConfig {
    * Chain id used in the signature of meta-tx
    */
   chainId?: number
+}
+
+export interface ProviderUrl {
+  /**
+   * Protocol for communicating with a relay server
+   */
+  protocol?: string
+  /**
+   * Host of a relay server
+   */
+  host?: string
+  /**
+   * Port for communication
+   */
+  port?: number | string
+  /**
+   * Base path for the relay api
+   */
+  path?: string
+  /**
+   * Protocol for WebSockets
+   */
+  wsProtocol?: string
 }
 
 /**

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -7,35 +7,19 @@ import { Options as ReconnectingOptions } from 'reconnecting-websocket'
  */
 export interface TLNetworkConfig {
   /**
-   * Url object for the trustline provider
+   * ProviderUrl object or full url for the relay api
    */
-  relayProviderUrlObject?: ProviderUrl
+  relayUrl?: string | ProviderUrl
   /**
-   * Url object for the messaging provider
+   * ProviderUrl object or full url for the messaging api
    */
-  messagingProviderUrlObject?: ProviderUrl
+  messagingUrl?: string | ProviderUrl
   /**
    * Web3 provider
    */
   web3Provider?: any
   /**
    * Full URL for trustline rest api
-   */
-  relayApiUrl?: string
-  /**
-   * Full URL for trustline WebSocket api
-   */
-  relayWsApiUrl?: string
-  /**
-   * Full URL for messaging rest api
-   */
-  messagingApiUrl?: string
-  /**
-   * Full URL for messaging WebSocket api
-   */
-  messagingWsApiUrl?: string
-  /**
-   * Wallet type to use, either "WalletTypeEthers" or "WalletTypeIdentity".
    */
   walletType?: string
   /**
@@ -69,10 +53,6 @@ export interface ProviderUrl {
    * Base path for the relay api
    */
   path?: string
-  /**
-   * Protocol for WebSockets
-   */
-  wsProtocol?: string
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -434,8 +434,10 @@ export const buildApiUrl = (UrlObject: ProviderUrl): string => {
  * @param UrlObject.path relay api base endpoint
  */
 export const buildWsApiUrl = (UrlObject: ProviderUrl): string => {
-  return `${UrlObject.wsProtocol}://${UrlObject.host}${UrlObject.port &&
-    `:${UrlObject.port}`}${UrlObject.path && `/${trimUrl(UrlObject.path)}`}`
+  return `${UrlObject.protocol === 'https' ? 'wss' : 'ws'}://${
+    UrlObject.host
+  }${UrlObject.port && `:${UrlObject.port}`}${UrlObject.path &&
+    `/${trimUrl(UrlObject.path)}`}`
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import { Observer } from 'rxjs/Observer'
 import JsonRPC from 'simple-jsonrpc-js'
 import NodeWebSocket from 'ws'
 
+import { Provider } from 'ethers/providers'
 import {
   Amount,
   AmountInternal,
@@ -17,6 +18,7 @@ import {
   DelegationFeesObject,
   ExchangeCancelEventRaw,
   ExchangeFillEventRaw,
+  ProviderUrl,
   ReconnectingWSOptions
 } from './typings'
 
@@ -413,20 +415,27 @@ export const isURL = str => {
 }
 
 /**
- * Returns URL by concatenating protocol, host, port and path.
- * @param protocol relay api endpoint protocol
- * @param host relay api host address
- * @param port relay api port
- * @param path relay api base endpoint
+ * Returns URL by concatenating protocol, host, port and path from ProviderUrl object.
+ * @param UrlObject.protocol relay api endpoint protocol
+ * @param UrlObject.host relay api host address
+ * @param UrlObject.port relay api port
+ * @param UrlObject.path relay api base endpoint
  */
-export const buildApiUrl = (
-  protocol: string,
-  host: string,
-  port: number | string,
-  path: string
-): string => {
-  return `${protocol}://${host}${port && `:${port}`}${path &&
-    `/${trimUrl(path)}`}`
+export const buildApiUrl = (UrlObject: ProviderUrl): string => {
+  return `${UrlObject.protocol}://${UrlObject.host}${UrlObject.port &&
+    `:${UrlObject.port}`}${UrlObject.path && `/${trimUrl(UrlObject.path)}`}`
+}
+
+/**
+ * Returns URL by concatenating protocol, host, port and path.
+ * @param UrlObject.wsProtocol relay ws api endpoint protocol
+ * @param UrlObject.host relay api host address
+ * @param UrlObject.port relay api port
+ * @param UrlObject.path relay api base endpoint
+ */
+export const buildWsApiUrl = (UrlObject: ProviderUrl): string => {
+  return `${UrlObject.wsProtocol}://${UrlObject.host}${UrlObject.port &&
+    `:${UrlObject.port}`}${UrlObject.path && `/${trimUrl(UrlObject.path)}`}`
 }
 
 /**
@@ -453,6 +462,7 @@ export const trimUrl = (url: string): string => {
 
 export default {
   buildApiUrl,
+  buildWsApiUrl,
   buildUrl,
   calcRaw,
   calcValue,

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -13,6 +13,8 @@ import {
   EthersWalletData,
   IdentityWalletData,
   MetaTransaction,
+  ProviderUrl,
+  TLNetworkConfig,
   TLWalletData
 } from '../src/typings'
 
@@ -23,19 +25,23 @@ export const identityFactoryAddress = identityConfig.identityProxyFactory
 export const identityImplementationAddress =
   identityConfig.identityImplementation
 
-export const tlNetworkConfig = {
+export const providerUrl: ProviderUrl = {
   host: process.env.RELAY_HOSTNAME || 'localhost',
   path: 'api/v1/',
   port: 5000,
   protocol: 'http',
+  wsProtocol: 'ws'
+}
+
+export const tlNetworkConfig: TLNetworkConfig = {
+  relayProviderUrlObject: providerUrl,
+  messagingProviderUrlObject: providerUrl,
   chainId: end2endChainId
 }
 
-export const tlNetworkConfigIdentity = {
-  host: process.env.RELAY_HOSTNAME || 'localhost',
-  path: 'api/v1/',
-  port: 5000,
-  protocol: 'http',
+export const tlNetworkConfigIdentity: TLNetworkConfig = {
+  relayProviderUrlObject: providerUrl,
+  messagingProviderUrlObject: providerUrl,
   walletType: WALLET_TYPE_IDENTITY,
   identityFactoryAddress: identityConfig.identityProxyFactory,
   identityImplementationAddress: identityConfig.identityImplementation,

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -29,19 +29,18 @@ export const providerUrl: ProviderUrl = {
   host: process.env.RELAY_HOSTNAME || 'localhost',
   path: 'api/v1/',
   port: 5000,
-  protocol: 'http',
-  wsProtocol: 'ws'
+  protocol: 'http'
 }
 
 export const tlNetworkConfig: TLNetworkConfig = {
-  relayProviderUrlObject: providerUrl,
-  messagingProviderUrlObject: providerUrl,
+  relayUrl: providerUrl,
+  messagingUrl: providerUrl,
   chainId: end2endChainId
 }
 
 export const tlNetworkConfigIdentity: TLNetworkConfig = {
-  relayProviderUrlObject: providerUrl,
-  messagingProviderUrlObject: providerUrl,
+  relayUrl: providerUrl,
+  messagingUrl: providerUrl,
   walletType: WALLET_TYPE_IDENTITY,
   identityFactoryAddress: identityConfig.identityProxyFactory,
   identityImplementationAddress: identityConfig.identityImplementation,

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -40,16 +40,9 @@ describe('e2e', () => {
     let trustlinesNetwork2: TLNetwork
 
     before(async () => {
-      const relayApiUrl = utils.buildApiUrl(
-        tlNetworkConfig.relayProviderUrlObject
-      )
-      const relayWsUrl = utils.buildWsApiUrl(
-        tlNetworkConfig.relayProviderUrlObject
-      )
-      relayProvider = new RelayProvider(relayApiUrl, relayWsUrl)
-
       trustlinesNetwork = new TLNetwork(tlNetworkConfigIdentity)
       trustlinesNetwork2 = new TLNetwork(tlNetworkConfigIdentity)
+      relayProvider = trustlinesNetwork.relayProvider
 
       identityWallet = trustlinesNetwork.wallet
     })

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -40,12 +40,13 @@ describe('e2e', () => {
     let trustlinesNetwork2: TLNetwork
 
     before(async () => {
-      const { host, path, port, protocol } = tlNetworkConfig
-      const wsProtocol = 'ws'
-
-      const relayApiUrl = utils.buildApiUrl(protocol, host, port, path)
-      const relayWpUrl = utils.buildApiUrl(wsProtocol, host, port, path)
-      relayProvider = new RelayProvider(relayApiUrl, relayWpUrl)
+      const relayApiUrl = utils.buildApiUrl(
+        tlNetworkConfig.relayProviderUrlObject
+      )
+      const relayWsUrl = utils.buildWsApiUrl(
+        tlNetworkConfig.relayProviderUrlObject
+      )
+      relayProvider = new RelayProvider(relayApiUrl, relayWsUrl)
 
       trustlinesNetwork = new TLNetwork(tlNetworkConfigIdentity)
       trustlinesNetwork2 = new TLNetwork(tlNetworkConfigIdentity)

--- a/tests/e2e/Information.test.ts
+++ b/tests/e2e/Information.test.ts
@@ -37,7 +37,7 @@ describe('e2e', () => {
         information = new Information({
           user: tl1.user,
           currencyNetwork: tl1.currencyNetwork,
-          provider: tl1.provider
+          provider: tl1.relayProvider
         })
         await deployIdentities([tl1, tl2])
         // request ETH

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -24,8 +24,8 @@ import {
 } from '../../src/typings'
 
 export class FakeTLProvider implements TLProvider {
-  public relayApiUrl = FAKE_RELAY_API
-  public relayWsApiUrl = FAKE_RELAY_API
+  public ApiUrl = FAKE_RELAY_API
+  public WsApiUrl = FAKE_RELAY_API
   public errors: any = {}
 
   /**

--- a/tests/unit/RelayProvider.test.ts
+++ b/tests/unit/RelayProvider.test.ts
@@ -70,7 +70,7 @@ describe('unit', () => {
       beforeEach(() => init())
 
       it('return version of relay', async () => {
-        const relayVersion = await relayProvider.getRelayVersion()
+        const relayVersion = await relayProvider.getVersion()
         assert.isString(relayVersion)
         assert.isTrue(new RegExp(/relay\/v\d/).test(relayVersion))
       })

--- a/tests/unit/TLNetwork.test.ts
+++ b/tests/unit/TLNetwork.test.ts
@@ -8,18 +8,20 @@ describe('unit', () => {
     describe('#constructor()', () => {
       it('should load default configuration', () => {
         const tlNetwork = new TLNetwork()
-        expect(tlNetwork.provider.relayApiUrl).to.equal('http://localhost')
+        expect(tlNetwork.relayProvider.ApiUrl).to.equal('http://localhost')
       })
 
       it('should load custom configuration', () => {
         const tlNetwork = new TLNetwork({
-          host: '192.168.0.59',
-          path: 'api/v1',
-          port: 5000,
-          protocol: 'https'
+          relayProviderUrlObject: {
+            host: '192.168.0.59',
+            path: 'api/v1',
+            port: 5000,
+            protocol: 'https'
+          }
         })
         expect(tlNetwork).to.be.an('object')
-        expect(tlNetwork.provider.relayApiUrl).to.equal(
+        expect(tlNetwork.relayProvider.ApiUrl).to.equal(
           'https://192.168.0.59:5000/api/v1'
         )
       })

--- a/tests/unit/TLNetwork.test.ts
+++ b/tests/unit/TLNetwork.test.ts
@@ -9,20 +9,38 @@ describe('unit', () => {
       it('should load default configuration', () => {
         const tlNetwork = new TLNetwork()
         expect(tlNetwork.relayProvider.ApiUrl).to.equal('http://localhost')
+        expect(tlNetwork.relayProvider.WsApiUrl).to.equal('ws://localhost')
+        expect(tlNetwork.messagingProvider.ApiUrl).to.equal('http://localhost')
+        expect(tlNetwork.messagingProvider.WsApiUrl).to.equal('ws://localhost')
       })
 
       it('should load custom configuration', () => {
         const tlNetwork = new TLNetwork({
-          relayProviderUrlObject: {
+          relayUrl: {
             host: '192.168.0.59',
             path: 'api/v1',
             port: 5000,
             protocol: 'https'
+          },
+          messagingUrl: {
+            host: '192.168.0.1',
+            path: 'messaging/api/v1',
+            port: 4000,
+            protocol: 'http'
           }
         })
         expect(tlNetwork).to.be.an('object')
         expect(tlNetwork.relayProvider.ApiUrl).to.equal(
           'https://192.168.0.59:5000/api/v1'
+        )
+        expect(tlNetwork.relayProvider.WsApiUrl).to.equal(
+          'wss://192.168.0.59:5000/api/v1'
+        )
+        expect(tlNetwork.messagingProvider.ApiUrl).to.equal(
+          'http://192.168.0.1:4000/messaging/api/v1'
+        )
+        expect(tlNetwork.messagingProvider.WsApiUrl).to.equal(
+          'ws://192.168.0.1:4000/messaging/api/v1'
         )
       })
     })


### PR DESCRIPTION
I put the function `getVersion()` in the base `Provider.ts` even though it assumes the provider implements an endpoint `version` but I felt like it was not so much to assume and would prove useful.
closes: https://github.com/trustlines-protocol/clientlib/issues/309