### PR TITLE
Use valide zero address as currency network of fees instead of ''

### DIFF
--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -70,7 +70,7 @@ export class RelayProvider extends Provider implements TLProvider {
     )
     let baseFee = '0'
     let gasPrice = '0'
-    let currencyNetworkOfFees = ''
+    let currencyNetworkOfFees = '0x' + '0'.repeat(40)
     if (potentialDelegationFees.length) {
       // For now just get the first possible fee given by the relay server
       // Could be changed later to show the possible fees to the user and let it decide

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -378,6 +378,7 @@ export class IdentityWallet implements TLWallet {
   }
 
   private buildMetaTransaction(rawTx: RawTxObject): MetaTransaction {
+    const zeroAddress = '0x' + '0'.repeat(40)
     return {
       data: rawTx.data || '0x',
       from: rawTx.from,
@@ -396,7 +397,7 @@ export class IdentityWallet implements TLWallet {
       feeRecipient: '0x' + '0'.repeat(40),
       currencyNetworkOfFees: rawTx.delegationFees
         ? rawTx.delegationFees.currencyNetworkOfFees
-        : rawTx.to,
+        : zeroAddress,
       timeLimit: '0',
       operationType: 0
     }


### PR DESCRIPTION
When the relay replies with no delegation fees, we used '' as
delegation fees which could not be hashed, we now use a valid
zero address.
Also use a zero address as default when building a meta-tx when
no fees are provided for consistency.

I tested it by running the e2e tests with no delegation fees in config:
```
[relay]
syncInterval = 300
updateNetworksInterval = 5
enableEtherFaucet = true
enableRelayMetaTransaction = true
enableDeployIdentity = true

[relay.rpc]
host = "node"
port = 8545
ssl = false
```

closes https://github.com/trustlines-protocol/clientlib/issues/313