### PR TITLE
Add new event identifier field

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -105,6 +105,7 @@ export interface EventFilterOptions {
 }
 
 export interface BlockchainEvent {
+  id: string
   type: string
   timestamp: number
   blockNumber: number

--- a/tests/e2e/Exchange.test.ts
+++ b/tests/e2e/Exchange.test.ts
@@ -329,7 +329,8 @@ describe('e2e', () => {
         'transactionId',
         'from',
         'to',
-        'direction'
+        'direction',
+        'id'
       ]
       const fillEventKeys = exEventKeys.concat([
         'filledMakerAmount',


### PR DESCRIPTION
This fixes the end-to-end test due to new event identifier field introduced to the relay by trustlines-protocol/relay#428