### PR TITLE
Fix random number generation boundaries

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -389,9 +389,8 @@ export const convertToHexString = (
  */
 export const generateRandomNumber = (decimals: number): BigNumber => {
   let random = BigNumber.random(decimals + 1)
-  const one = new BigNumber(1)
 
-  while (random === one) {
+  while (random.isEqualTo(1)) {
     random = BigNumber.random(decimals + 1)
   }
   return random.multipliedBy(new BigNumber(10).pow(decimals)).integerValue()


### PR DESCRIPTION
I strumbled over that due to [this CI run](https://circleci.com/gh/trustlines-protocol/clientlib/2069?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).
The `===` operator does not work for objects like the BigNumber class.

See also: #279