### PR TITLE
Add useful value for delegation fees in payments sending eth

### DIFF
--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -9,6 +9,7 @@ import { User } from './User'
 import utils from './utils'
 
 import {
+  DelegationFeesInternal,
   EventFilterOptions,
   FeePayer,
   isFeePayerValue,
@@ -120,7 +121,10 @@ export class Payment {
       )
       return {
         ethFees: utils.convertToAmount(ethFees),
-        delegationFees: utils.convertToDelegationFees(delegationFees),
+        delegationFees: utils.calculateDelegationFeesAmount(
+          delegationFees,
+          this.calculatePaymentGasLimit(path.length)
+        ),
         feePayer,
         maxFees,
         path,
@@ -160,7 +164,10 @@ export class Payment {
     )
     return {
       ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.convertToDelegationFees(delegationFees),
+      delegationFees: utils.calculateDelegationFeesAmount(
+        delegationFees,
+        21000
+      ),
       rawTx
     }
   }
@@ -297,5 +304,13 @@ export class Payment {
       amount: utils.formatToAmount(result.capacity, networkDecimals),
       path: result.path
     }
+  }
+
+  private calculatePaymentGasLimit(pathLength: number) {
+    // Values taken from the contracts repository gas tests
+    const transferBaseGas = 48000
+    const gasPerHops = 18000
+    const bufferMultiplier = 1.2
+    return (transferBaseGas + gasPerHops * pathLength) * bufferMultiplier
   }
 }

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -310,6 +310,8 @@ export class Payment {
     const mediators = pathLength - 2
     const transferBaseGas = 48000
     const gasPerMediator = 18000
-    return (transferBaseGas + gasPerMediator * mediators) * GAS_LIMIT_MULTIPLIER
+    return Math.floor(
+      (transferBaseGas + gasPerMediator * mediators) * GAS_LIMIT_MULTIPLIER
+    )
   }
 }

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -3,13 +3,12 @@ import { BigNumber } from 'bignumber.js'
 import { CurrencyNetwork } from './CurrencyNetwork'
 import { Event } from './Event'
 import { TLProvider } from './providers/TLProvider'
-import { Transaction } from './Transaction'
+import { GAS_LIMIT_MULTIPLIER, Transaction } from './Transaction'
 import { User } from './User'
 
 import utils from './utils'
 
 import {
-  DelegationFeesInternal,
   EventFilterOptions,
   FeePayer,
   isFeePayerValue,
@@ -308,9 +307,9 @@ export class Payment {
 
   private calculatePaymentGasLimit(pathLength: number) {
     // Values taken from the contracts repository gas tests
+    const mediators = pathLength - 2
     const transferBaseGas = 48000
-    const gasPerHops = 18000
-    const bufferMultiplier = 1.2
-    return (transferBaseGas + gasPerHops * pathLength) * bufferMultiplier
+    const gasPerMediator = 18000
+    return (transferBaseGas + gasPerMediator * mediators) * GAS_LIMIT_MULTIPLIER
   }
 }

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -18,6 +18,7 @@ import {
 import { CurrencyNetwork } from './CurrencyNetwork'
 
 const ETH_DECIMALS = 18
+export const GAS_LIMIT_MULTIPLIER = 1.2
 
 /**
  * The Transaction class contains functions that are needed for Ethereum transactions.

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -182,7 +182,9 @@ export class Trustline {
     )
     // Value taken from contracts repository gas tests
     // TODO: the gas limit for updating a TL could actually be lower than this depending on the situation
-    const MaxTrustlineUpdateGasLimit = 315_000 * GAS_LIMIT_MULTIPLIER
+    const MaxTrustlineUpdateGasLimit = Math.floor(
+      315_000 * GAS_LIMIT_MULTIPLIER
+    )
     return {
       ethFees: utils.convertToAmount(ethFees),
       delegationFees: utils.calculateDelegationFeesAmount(
@@ -263,7 +265,9 @@ export class Trustline {
       }
     )
     // Value taken from contracts gas tests
-    const gasLimitCancelTrustlineUpdate = 19000 * GAS_LIMIT_MULTIPLIER
+    const gasLimitCancelTrustlineUpdate = Math.floor(
+      19000 * GAS_LIMIT_MULTIPLIER
+    )
     return {
       ethFees: utils.convertToAmount(ethFees),
       delegationFees: utils.calculateDelegationFeesAmount(
@@ -481,7 +485,7 @@ export class Trustline {
     )
 
     // Value taken from contracts gas tests
-    const gasLimitCloseTrustline = 55000 * GAS_LIMIT_MULTIPLIER
+    const gasLimitCloseTrustline = Math.floor(55000 * GAS_LIMIT_MULTIPLIER)
     return {
       ethFees: utils.convertToAmount(ethFees),
       delegationFees: utils.calculateDelegationFeesAmount(

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -180,9 +180,15 @@ export class Trustline {
         gasPrice: gasPrice ? new BigNumber(gasPrice) : undefined
       }
     )
+    // Value taken from contracts repository gas tests
+    // TODO: the gas limit for updating a TL could actually be lower than this depending on the situation
+    const MaxTrustlineUpdateGasLimit = 315_000 * 1.2
     return {
       ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.convertToDelegationFees(delegationFees),
+      delegationFees: utils.calculateDelegationFeesAmount(
+        delegationFees,
+        MaxTrustlineUpdateGasLimit
+      ),
       rawTx
     }
   }
@@ -256,9 +262,14 @@ export class Trustline {
         gasPrice: gasPrice ? new BigNumber(gasPrice) : undefined
       }
     )
+    // Value taken from contracts gas tests
+    const gasLimitCancelTrustlineUpdate = 19000 * 1.2
     return {
       ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.convertToDelegationFees(delegationFees),
+      delegationFees: utils.calculateDelegationFeesAmount(
+        delegationFees,
+        gasLimitCancelTrustlineUpdate
+      ),
       rawTx
     }
   }
@@ -469,9 +480,14 @@ export class Trustline {
       }
     )
 
+    // Value taken from contracts gas tests
+    const gasLimitCloseTrustline = 55000 * 1.2
     return {
       ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.convertToDelegationFees(delegationFees),
+      delegationFees: utils.calculateDelegationFeesAmount(
+        delegationFees,
+        gasLimitCloseTrustline
+      ),
       maxFees,
       path,
       rawTx

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js'
 import { CurrencyNetwork } from './CurrencyNetwork'
 import { Event } from './Event'
 import { TLProvider } from './providers/TLProvider'
-import { Transaction } from './Transaction'
+import { GAS_LIMIT_MULTIPLIER, Transaction } from './Transaction'
 import { User } from './User'
 
 import utils from './utils'
@@ -182,7 +182,7 @@ export class Trustline {
     )
     // Value taken from contracts repository gas tests
     // TODO: the gas limit for updating a TL could actually be lower than this depending on the situation
-    const MaxTrustlineUpdateGasLimit = 315_000 * 1.2
+    const MaxTrustlineUpdateGasLimit = 315_000 * GAS_LIMIT_MULTIPLIER
     return {
       ethFees: utils.convertToAmount(ethFees),
       delegationFees: utils.calculateDelegationFeesAmount(
@@ -263,7 +263,7 @@ export class Trustline {
       }
     )
     // Value taken from contracts gas tests
-    const gasLimitCancelTrustlineUpdate = 19000 * 1.2
+    const gasLimitCancelTrustlineUpdate = 19000 * GAS_LIMIT_MULTIPLIER
     return {
       ethFees: utils.convertToAmount(ethFees),
       delegationFees: utils.calculateDelegationFeesAmount(
@@ -481,7 +481,7 @@ export class Trustline {
     )
 
     // Value taken from contracts gas tests
-    const gasLimitCloseTrustline = 55000 * 1.2
+    const gasLimitCloseTrustline = 55000 * GAS_LIMIT_MULTIPLIER
     return {
       ethFees: utils.convertToAmount(ethFees),
       delegationFees: utils.calculateDelegationFeesAmount(

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -241,7 +241,7 @@ export type AmountEventRaw = NetworkTransferEventRaw | TokenAmountEventRaw
 export interface TxObject {
   rawTx: RawTxObject
   ethFees: Amount
-  delegationFees?: DelegationFeesObject
+  delegationFees?: Amount
 }
 
 export interface TxObjectInternal {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,6 @@ import { Observer } from 'rxjs/Observer'
 import JsonRPC from 'simple-jsonrpc-js'
 import NodeWebSocket from 'ws'
 
-import { Provider } from 'ethers/providers'
 import {
   Amount,
   AmountInternal,
@@ -278,7 +277,7 @@ export const calculateDelegationFeesAmount = (
   const totalFeesRaw = delegationFees.baseFee.raw.plus(
     delegationFees.gasPrice.raw
       .multipliedBy(gasLimit)
-      .dividedToIntegerBy(1_000_000)
+      .dividedToIntegerBy(DELEGATION_GAS_PRICE_DIVISOR)
   )
   return {
     raw: totalFeesRaw.toString(),
@@ -286,6 +285,9 @@ export const calculateDelegationFeesAmount = (
     decimals: delegationFees.baseFee.decimals
   }
 }
+
+// This constant is taken from the identity contracts where the gas price is divided before used in fee calculation
+export const DELEGATION_GAS_PRICE_DIVISOR = 1_000_000
 
 /**
  * Formats the number values of a raw event returned by the relay.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,12 +275,14 @@ export const calculateDelegationFeesAmount = (
   delegationFees: DelegationFeesInternal,
   gasLimit: number
 ): Amount => {
-  const totalFeesValue = delegationFees.baseFee.value.plus(
-    delegationFees.gasPrice.value.multipliedBy(gasLimit)
+  const totalFeesRaw = delegationFees.baseFee.raw.plus(
+    delegationFees.gasPrice.raw
+      .multipliedBy(gasLimit)
+      .dividedToIntegerBy(1_000_000)
   )
   return {
-    raw: calcRaw(totalFeesValue, delegationFees.baseFee.decimals).toString(),
-    value: totalFeesValue.toString(),
+    raw: totalFeesRaw.toString(),
+    value: calcValue(totalFeesRaw, delegationFees.baseFee.decimals).toString(),
     decimals: delegationFees.baseFee.decimals
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -271,6 +271,20 @@ export const convertToDelegationFees = (
   }
 }
 
+export const calculateDelegationFeesAmount = (
+  delegationFees: DelegationFeesInternal,
+  gasLimit: number
+): Amount => {
+  const totalFeesValue = delegationFees.baseFee.value.plus(
+    delegationFees.gasPrice.value.multipliedBy(gasLimit)
+  )
+  return {
+    raw: calcRaw(totalFeesValue, delegationFees.baseFee.decimals).toString(),
+    value: totalFeesValue.toString(),
+    decimals: delegationFees.baseFee.decimals
+  }
+}
+
 /**
  * Formats the number values of a raw event returned by the relay.
  * @param event raw event
@@ -467,6 +481,7 @@ export default {
   buildUrl,
   calcRaw,
   calcValue,
+  calculateDelegationFeesAmount,
   checkAddress,
   convertEthToWei,
   convertToAmount,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,7 +258,7 @@ export const formatToDelegationFeesInternal = (
 }
 
 /**
- * Formats number into an AmountInternal object which is intended for internal use.
+ * Formats DelegationFeesInternal into a DelegationFeesObject.
  * @param delegationFees DelegationFeesInternal object.
  */
 export const convertToDelegationFees = (

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -247,6 +247,7 @@ describe('e2e', () => {
           'currencyNetworkOfFees'
         )
         expect(metaTransactionFees.baseFee).to.equal('1')
+        expect(metaTransactionFees.gasPrice).to.equal('1000')
       })
     })
 

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -176,6 +176,34 @@ describe('e2e', () => {
             tl1.payment.prepare(network.address, user2.address, 2000)
           ).to.be.rejectedWith('Could not find a path with enough capacity')
         })
+
+        if (testParameter.walletType === 'Identity') {
+          it('should have correct delegation fees for trustline transfer', async () => {
+            const preparedPayment = await tl1.payment.prepare(
+              network.address,
+              user2.address,
+              2.25
+            )
+
+            // gasLimitForTransfer * buffer * gasPrice / gasDivisorFromContracts + baseFee
+            const delegationFeeRaw = Math.floor(
+              (48000 * 1.2 * 1000) / 1_000_000 + 1
+            )
+
+            expect(preparedPayment.delegationFees.raw).to.equal(
+              delegationFeeRaw.toString(),
+              'Incorrect delegationFees raw'
+            )
+            expect(preparedPayment.delegationFees.value).to.equal(
+              (delegationFeeRaw / 10_000).toString(),
+              'Incorrect delegationFees value'
+            )
+            expect(preparedPayment.delegationFees.decimals).to.equal(
+              4,
+              'Incorrect delegationFees decimals'
+            )
+          })
+        }
       })
 
       describe('#confirm()', () => {


### PR DESCRIPTION
Requires a PR in end2end repo to set gasPrice to 1000. I cannot push it because Github seems to bug. I'll try later.