### PR TITLE
Feature/use gas limit meta tx

### DIFF
--- a/src/EthWrapper.ts
+++ b/src/EthWrapper.ts
@@ -70,10 +70,7 @@ export class EthWrapper {
     options: TxOptions = {}
   ): Promise<TxObject> {
     const { gasPrice, gasLimit } = options
-    const {
-      rawTx,
-      ethFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       ethWrapperAddress,
       'UnwEth',
@@ -88,7 +85,7 @@ export class EthWrapper {
       }
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
+      txFees,
       rawTx
     }
   }
@@ -107,10 +104,7 @@ export class EthWrapper {
     options: TxOptions = {}
   ): Promise<TxObject> {
     const { gasPrice, gasLimit } = options
-    const {
-      rawTx,
-      ethFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       ethWrapperAddress,
       'UnwEth',
@@ -123,7 +117,7 @@ export class EthWrapper {
       }
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
+      txFees,
       rawTx
     }
   }
@@ -142,10 +136,7 @@ export class EthWrapper {
     options: TxOptions = {}
   ): Promise<TxObject> {
     const { gasPrice, gasLimit } = options
-    const {
-      rawTx,
-      ethFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       ethWrapperAddress,
       'UnwEth',
@@ -157,7 +148,7 @@ export class EthWrapper {
       }
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
+      txFees,
       rawTx
     }
   }

--- a/src/Exchange.ts
+++ b/src/Exchange.ts
@@ -326,10 +326,7 @@ export class Exchange {
     ) {
       throw new Error('Could not find a path with enough capacity')
     }
-    const {
-      rawTx,
-      ethFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       exchangeContractAddress,
       'Exchange',
@@ -356,7 +353,7 @@ export class Exchange {
       }
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
+      txFees,
       makerMaxFees: makerPathObj.maxFees,
       makerPath: makerPathObj.path,
       rawTx,
@@ -391,10 +388,7 @@ export class Exchange {
     })
     const orderAddresses = this._getOrderAddresses(signedOrder)
     const orderValues = this._getOrderValues(signedOrder)
-    const {
-      rawTx,
-      ethFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       exchangeContractAddress,
       'Exchange',
@@ -412,7 +406,7 @@ export class Exchange {
       }
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
+      txFees,
       rawTx
     }
   }

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -97,8 +97,7 @@ export class Payment {
     if (path.length > 0) {
       const {
         rawTx,
-        ethFees,
-        delegationFees
+        txFees
       } = await this.transaction.prepareContractTransaction(
         await this.user.getAddress(),
         networkAddress,
@@ -119,11 +118,7 @@ export class Payment {
         }
       )
       return {
-        ethFees: utils.convertToAmount(ethFees),
-        delegationFees: utils.calculateDelegationFeesAmount(
-          delegationFees,
-          this.calculatePaymentGasLimit(path.length)
-        ),
+        txFees,
         feePayer,
         maxFees,
         path,
@@ -148,11 +143,7 @@ export class Payment {
     options: PaymentOptions = {}
   ): Promise<TxObject> {
     const { gasLimit, gasPrice } = options
-    const {
-      ethFees,
-      rawTx,
-      delegationFees
-    } = await this.transaction.prepareValueTransaction(
+    const { txFees, rawTx } = await this.transaction.prepareValueTransaction(
       await this.user.getAddress(),
       receiverAddress,
       utils.calcRaw(value, 18),
@@ -162,11 +153,7 @@ export class Payment {
       }
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.calculateDelegationFeesAmount(
-        delegationFees,
-        21000
-      ),
+      txFees,
       rawTx
     }
   }

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -3,7 +3,7 @@ import { BigNumber } from 'bignumber.js'
 import { CurrencyNetwork } from './CurrencyNetwork'
 import { Event } from './Event'
 import { TLProvider } from './providers/TLProvider'
-import { GAS_LIMIT_MULTIPLIER, Transaction } from './Transaction'
+import { Transaction } from './Transaction'
 import { User } from './User'
 
 import utils from './utils'
@@ -113,7 +113,9 @@ export class Payment {
           extraData || '0x'
         ],
         {
-          gasLimit: gasLimit ? new BigNumber(gasLimit) : undefined,
+          gasLimit: gasLimit
+            ? new BigNumber(gasLimit)
+            : utils.calculateTransferGasLimit(path.length),
           gasPrice: gasPrice ? new BigNumber(gasPrice) : undefined
         }
       )
@@ -290,15 +292,5 @@ export class Payment {
       amount: utils.formatToAmount(result.capacity, networkDecimals),
       path: result.path
     }
-  }
-
-  private calculatePaymentGasLimit(pathLength: number) {
-    // Values taken from the contracts repository gas tests
-    const mediators = pathLength - 2
-    const transferBaseGas = 48000
-    const gasPerMediator = 18000
-    return Math.floor(
-      (transferBaseGas + gasPerMediator * mediators) * GAS_LIMIT_MULTIPLIER
-    )
   }
 }

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -165,11 +165,7 @@ export class Trustline {
       )
     }
 
-    const {
-      rawTx,
-      ethFees,
-      delegationFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       networkAddress,
       'CurrencyNetwork',
@@ -186,11 +182,7 @@ export class Trustline {
       315_000 * GAS_LIMIT_MULTIPLIER
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.calculateDelegationFeesAmount(
-        delegationFees,
-        MaxTrustlineUpdateGasLimit
-      ),
+      txFees,
       rawTx
     }
   }
@@ -249,11 +241,7 @@ export class Trustline {
     const cancelFuncName = 'cancelTrustlineUpdate'
     const cancelFuncArgs: any[] = [counterpartyAddress]
 
-    const {
-      rawTx,
-      ethFees,
-      delegationFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       networkAddress,
       'CurrencyNetwork',
@@ -269,11 +257,7 @@ export class Trustline {
       19000 * GAS_LIMIT_MULTIPLIER
     )
     return {
-      ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.calculateDelegationFeesAmount(
-        delegationFees,
-        gasLimitCancelTrustlineUpdate
-      ),
+      txFees,
       rawTx
     }
   }
@@ -468,11 +452,7 @@ export class Trustline {
     }
 
     // Prepare the interaction with the contract.
-    const {
-      rawTx,
-      ethFees,
-      delegationFees
-    } = await this.transaction.prepareContractTransaction(
+    const { rawTx, txFees } = await this.transaction.prepareContractTransaction(
       await this.user.getAddress(),
       networkAddress,
       'CurrencyNetwork',
@@ -487,11 +467,7 @@ export class Trustline {
     // Value taken from contracts gas tests
     const gasLimitCloseTrustline = Math.floor(55000 * GAS_LIMIT_MULTIPLIER)
     return {
-      ethFees: utils.convertToAmount(ethFees),
-      delegationFees: utils.calculateDelegationFeesAmount(
-        delegationFees,
-        gasLimitCloseTrustline
-      ),
+      txFees,
       maxFees,
       path,
       rawTx

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -38,20 +38,15 @@ export class RelayProvider extends Provider implements TLProvider {
   }
 
   /**
-   * Returns needed information for creating a meta transaction.
-   * @param address Address of user creating the transaction
-   * @returns Information for creating an ethereum transaction for the given identity address.
-   *          See type `TxInfos` for more details.
+   * Returns next nonce for identity with given address
+   * @param address Address of identity
+   * @returns the next nonce that should be used for making a meta-transaction
    */
-  public async getMetaTxInfos(address: string): Promise<TxInfos> {
+  public async getIdentityNonce(address: string): Promise<number> {
     const { identity, nextNonce, balance } = await this.fetchEndpoint<any>(
       `/identities/${address}`
     )
-    return {
-      balance: new BigNumber(balance),
-      gasPrice: new BigNumber(0),
-      nonce: nextNonce
-    }
+    return nextNonce
   }
 
   /**

--- a/src/providers/TLProvider.ts
+++ b/src/providers/TLProvider.ts
@@ -22,7 +22,7 @@ export interface TLProvider {
     reconnectingOptions?: ReconnectingWSOptions
   ): any
   getTxInfos(userAddress: string): Promise<TxInfos>
-  getMetaTxInfos(userAddress: string): Promise<TxInfos>
+  getIdentityNonce(userAddress: string): Promise<number>
   getMetaTxFees(metaTransaction: MetaTransaction): Promise<MetaTransactionFees>
   getBalance(userAddress: string): Promise<Amount>
   sendSignedTransaction(signedTransaction: string): Promise<string>

--- a/src/signers/TLSigner.ts
+++ b/src/signers/TLSigner.ts
@@ -3,6 +3,7 @@ import {
   MetaTransactionFees,
   RawTxObject,
   Signature,
+  TxInfo,
   TxInfos
 } from '../typings'
 
@@ -15,6 +16,6 @@ export interface TLSigner {
   signMsgHash(msgHash: string): Promise<Signature>
   signMessage(message: string | ArrayLike<number>): Promise<Signature>
   confirm(rawTx: RawTxObject): Promise<string>
-  getTxInfos(userAddress: string): Promise<TxInfos>
+  fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject>
   getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees>
 }

--- a/src/signers/TLSigner.ts
+++ b/src/signers/TLSigner.ts
@@ -1,11 +1,4 @@
-import {
-  Amount,
-  MetaTransactionFees,
-  RawTxObject,
-  Signature,
-  TxInfo,
-  TxInfos
-} from '../typings'
+import { Amount, MetaTransactionFees, RawTxObject, Signature } from '../typings'
 
 /**
  * Interface for different signer strategies.

--- a/src/signers/Web3Signer.ts
+++ b/src/signers/Web3Signer.ts
@@ -131,6 +131,15 @@ export class Web3Signer implements TLSigner {
     return { balance, gasPrice, nonce }
   }
 
+  public async fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject> {
+    const { gasPrice, nonce } = await this.getTxInfos(this.address)
+    rawTx.gasPrice = gasPrice
+    rawTx.nonce = nonce
+    rawTx.baseFee = new BigNumber(0)
+    rawTx.totalFee = new BigNumber(rawTx.gasPrice).multipliedBy(rawTx.gasLimit)
+    return rawTx
+  }
+
   public async getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees> {
     return {
       baseFee: '0',

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -344,21 +344,6 @@ export interface TxInfos {
   nonce: number
 }
 
-export interface TxInfo {
-  /**
-   * Amount of ETH in gwei for every unit of gas user is willing to pay
-   */
-  gasPrice: BigNumber
-  gasLimit?: BigNumber
-  baseFee: BigNumber
-  totalFee: BigNumber
-  currencyNetworkOfFees?: string
-  /**
-   * Transaction count of given user address
-   */
-  nonce: number
-}
-
 export interface TxFeesAmounts {
   gasPrice: Amount
   gasLimit: Amount

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -60,9 +60,10 @@ export interface ProviderUrl {
  */
 export interface TxOptionsInternal {
   value?: BigNumber
-  gasPrice?: BigNumber
+  baseFee?: number | string | BigNumber
+  gasPrice?: number | string | BigNumber
   gasLimit?: BigNumber
-  delegationFees?: DelegationFeesRaw
+  currencyNetworkOfFees?: string
 }
 
 export interface TxOptions {
@@ -239,25 +240,25 @@ export type AmountEventRaw = NetworkTransferEventRaw | TokenAmountEventRaw
 // TRANSACTION
 export interface TxObject {
   rawTx: RawTxObject
-  ethFees: Amount
-  delegationFees?: Amount
+  txFees: TxFeesAmounts
 }
 
 export interface TxObjectInternal {
   rawTx: RawTxObject
-  ethFees: AmountInternal
-  delegationFees: DelegationFeesInternal
+  txFees: TxFeesAmounts
 }
 
 export interface RawTxObject {
   from: string
   to?: string
   value?: number | string | BigNumber
-  gasLimit?: number | string | BigNumber
-  gasPrice?: number | string | BigNumber
   data?: string
   nonce?: number
-  delegationFees?: DelegationFeesRaw
+  baseFee?: number | string | BigNumber
+  gasLimit?: number | string | BigNumber
+  gasPrice?: number | string | BigNumber
+  totalFee?: number | string | BigNumber
+  currencyNetworkOfFees?: string
 }
 
 export interface MetaTransaction {
@@ -341,6 +342,29 @@ export interface TxInfos {
    * Transaction count of given user address
    */
   nonce: number
+}
+
+export interface TxInfo {
+  /**
+   * Amount of ETH in gwei for every unit of gas user is willing to pay
+   */
+  gasPrice: BigNumber
+  gasLimit?: BigNumber
+  baseFee: BigNumber
+  totalFee: BigNumber
+  currencyNetworkOfFees?: string
+  /**
+   * Transaction count of given user address
+   */
+  nonce: number
+}
+
+export interface TxFeesAmounts {
+  gasPrice: Amount
+  gasLimit: Amount
+  baseFee: Amount
+  totalFee: Amount
+  currencyNetworkOfFees?: string
 }
 
 export interface DelegationFeesObject {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -286,6 +286,22 @@ export const calculateDelegationFeesAmount = (
   }
 }
 
+export const calculateDelegationFees = (
+  baseFee: number | string | BigNumber,
+  gasPrice: number | string | BigNumber,
+  gasLimit: number | string | BigNumber
+): BigNumber => {
+  const delegationFeesGasPriceDivisor = new BigNumber(1_000_000)
+  baseFee = new BigNumber(baseFee)
+  gasPrice = new BigNumber(gasPrice)
+  gasLimit = new BigNumber(gasLimit)
+  return baseFee.plus(
+    gasPrice
+      .multipliedBy(gasLimit)
+      .dividedToIntegerBy(delegationFeesGasPriceDivisor)
+  )
+}
+
 // This constant is taken from the identity contracts where the gas price is divided before used in fee calculation
 export const DELEGATION_GAS_PRICE_DIVISOR = 1_000_000
 
@@ -485,6 +501,7 @@ export default {
   buildUrl,
   calcRaw,
   calcValue,
+  calculateDelegationFees,
   calculateDelegationFeesAmount,
   checkAddress,
   convertEthToWei,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import { Observer } from 'rxjs/Observer'
 import JsonRPC from 'simple-jsonrpc-js'
 import NodeWebSocket from 'ws'
 
+import { GAS_COST_IDENTITY_OVERHEAD, GAS_LIMIT_MULTIPLIER } from './Transaction'
 import {
   Amount,
   AmountInternal,
@@ -302,6 +303,19 @@ export const calculateDelegationFees = (
   )
 }
 
+const GAS_COST_TRANSFER_BASE = new BigNumber(48000)
+const GAS_COST_TRANSFER_PER_MEDIATOR = new BigNumber(18000)
+
+export const calculateTransferGasLimit = (pathLength: number): BigNumber => {
+  // Values taken from the contracts repository gas tests
+  const mediators = pathLength - 2
+  return GAS_COST_TRANSFER_BASE.plus(
+    GAS_COST_TRANSFER_PER_MEDIATOR.multipliedBy(mediators)
+  )
+    .plus(GAS_COST_IDENTITY_OVERHEAD)
+    .multipliedBy(GAS_LIMIT_MULTIPLIER)
+}
+
 // This constant is taken from the identity contracts where the gas price is divided before used in fee calculation
 export const DELEGATION_GAS_PRICE_DIVISOR = 1_000_000
 
@@ -503,6 +517,7 @@ export default {
   calcValue,
   calculateDelegationFees,
   calculateDelegationFeesAmount,
+  calculateTransferGasLimit,
   checkAddress,
   convertEthToWei,
   convertToAmount,

--- a/src/wallets/EthersWallet.ts
+++ b/src/wallets/EthersWallet.ts
@@ -17,9 +17,7 @@ import {
   EthersWalletData,
   MetaTransactionFees,
   RawTxObject,
-  Signature,
-  TxInfo,
-  TxInfos
+  Signature
 } from '../typings'
 
 /**

--- a/src/wallets/EthersWallet.ts
+++ b/src/wallets/EthersWallet.ts
@@ -18,6 +18,7 @@ import {
   MetaTransactionFees,
   RawTxObject,
   Signature,
+  TxInfo,
   TxInfos
 } from '../typings'
 
@@ -265,8 +266,14 @@ export class EthersWallet implements TLWallet {
     throw new Error('Method not implemented.')
   }
 
-  public async getTxInfos(userAddress: string): Promise<TxInfos> {
-    return this.provider.getTxInfos(userAddress)
+  public async fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject> {
+    const { gasPrice, nonce } = await this.provider.getTxInfos(this.address)
+    rawTx.gasPrice = rawTx.gasPrice || gasPrice
+    rawTx.baseFee = new BigNumber(0)
+    rawTx.totalFee = new BigNumber(rawTx.gasPrice).multipliedBy(rawTx.gasLimit)
+    rawTx.nonce = nonce
+
+    return rawTx
   }
 
   public async getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees> {

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -17,9 +17,7 @@ import {
   MetaTransaction,
   MetaTransactionFees,
   RawTxObject,
-  Signature,
-  TxInfo,
-  TxInfos
+  Signature
 } from '../typings'
 
 import utils from '../utils'
@@ -323,13 +321,11 @@ export class IdentityWallet implements TLWallet {
 
     rawTx.gasPrice = rawTx.gasPrice || new BigNumber(metaTxFees.gasPrice)
     rawTx.baseFee = rawTx.baseFee || new BigNumber(metaTxFees.baseFee)
-    rawTx.totalFee =
-      rawTx.totalFee ||
-      utils.calculateDelegationFees(
-        rawTx.baseFee,
-        rawTx.gasPrice,
-        rawTx.gasLimit
-      )
+    rawTx.totalFee = utils.calculateDelegationFees(
+      rawTx.baseFee,
+      rawTx.gasPrice,
+      rawTx.gasLimit
+    )
     rawTx.currencyNetworkOfFees =
       rawTx.currencyNetworkOfFees || metaTxFees.currencyNetworkOfFees
 

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -18,10 +18,13 @@ import {
   MetaTransactionFees,
   RawTxObject,
   Signature,
+  TxInfo,
   TxInfos
 } from '../typings'
 
 import utils from '../utils'
+
+import BigNumber from 'bignumber.js'
 
 // This is the proxy initcode without the address of the owner but with added 0s so that we only need to append the address to it
 const initcodeWithPadding =
@@ -313,8 +316,24 @@ export class IdentityWallet implements TLWallet {
     return metaTransactionHash
   }
 
-  public async getTxInfos(userAddress: string): Promise<TxInfos> {
-    return this.provider.getMetaTxInfos(userAddress)
+  public async fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject> {
+    rawTx.nonce = await this.provider.getIdentityNonce(this.address)
+
+    const metaTxFees = await this.getMetaTxFees(rawTx)
+
+    rawTx.gasPrice = rawTx.gasPrice || new BigNumber(metaTxFees.gasPrice)
+    rawTx.baseFee = rawTx.baseFee || new BigNumber(metaTxFees.baseFee)
+    rawTx.totalFee =
+      rawTx.totalFee ||
+      utils.calculateDelegationFees(
+        rawTx.baseFee,
+        rawTx.gasPrice,
+        rawTx.gasLimit
+      )
+    rawTx.currencyNetworkOfFees =
+      rawTx.currencyNetworkOfFees || metaTxFees.currencyNetworkOfFees
+
+    return rawTx
   }
 
   public async getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees> {
@@ -387,17 +406,11 @@ export class IdentityWallet implements TLWallet {
       nonce: rawTx.nonce.toString(),
       to: rawTx.to,
       value: rawTx.value.toString(),
-      baseFee: rawTx.delegationFees
-        ? rawTx.delegationFees.baseFee.toString()
-        : '0',
-      gasPrice: rawTx.delegationFees
-        ? rawTx.delegationFees.gasPrice.toString()
-        : '0',
-      gasLimit: '0',
-      feeRecipient: '0x' + '0'.repeat(40),
-      currencyNetworkOfFees: rawTx.delegationFees
-        ? rawTx.delegationFees.currencyNetworkOfFees
-        : zeroAddress,
+      baseFee: rawTx.baseFee ? rawTx.baseFee.toString() : '0',
+      gasPrice: rawTx.gasPrice ? rawTx.gasPrice.toString() : '0',
+      gasLimit: rawTx.gasLimit ? rawTx.gasLimit.toString() : '0',
+      feeRecipient: zeroAddress,
+      currencyNetworkOfFees: rawTx.currencyNetworkOfFees || zeroAddress,
       timeLimit: '0',
       operationType: 0
     }

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -10,12 +10,15 @@ import {
 import identityConfig from './e2e-config/addresses.json'
 
 import {
+  Amount,
   EthersWalletData,
   IdentityWalletData,
   MetaTransaction,
   ProviderUrl,
+  RawTxObject,
   TLNetworkConfig,
-  TLWalletData
+  TLWalletData,
+  TxObjectInternal
 } from '../src/typings'
 
 export const end2endChainId = 17
@@ -213,24 +216,16 @@ export const FAKE_IDENTITY = {
   nextNonce: 10
 }
 
-export const FAKE_VALUE_TX_OBJECT_INTERNAL = {
-  ethFees: {
-    decimals: 18,
-    raw: new BigNumber(1000000000000000000),
-    value: new BigNumber(1)
-  },
-  delegationFees: {
-    baseFee: {
+export const FAKE_VALUE_TX_OBJECT_INTERNAL: TxObjectInternal = {
+  txFees: {
+    gasPrice: FAKE_AMOUNT,
+    gasLimit: FAKE_AMOUNT,
+    baseFee: FAKE_AMOUNT,
+    totalFee: {
       decimals: 18,
-      raw: new BigNumber(1000000000000000000),
-      value: new BigNumber(1)
-    },
-    gasPrice: {
-      decimals: 6,
-      raw: new BigNumber(0),
-      value: new BigNumber(0)
-    },
-    currencyNetworkOfFees: '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18'
+      raw: '1000000000000000000',
+      value: '1'
+    }
   },
   rawTx: {
     from: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
@@ -242,24 +237,16 @@ export const FAKE_VALUE_TX_OBJECT_INTERNAL = {
   }
 }
 
-export const FAKE_FUNC_TX_OBJECT_INTERNAL = {
-  ethFees: {
-    decimals: 18,
-    raw: new BigNumber(1000000000000000000),
-    value: new BigNumber(1)
-  },
-  delegationFees: {
-    baseFee: {
+export const FAKE_FUNC_TX_OBJECT_INTERNAL: TxObjectInternal = {
+  txFees: {
+    gasPrice: FAKE_AMOUNT,
+    gasLimit: FAKE_AMOUNT,
+    baseFee: FAKE_AMOUNT,
+    totalFee: {
       decimals: 18,
-      raw: new BigNumber(1000000000000000000),
-      value: new BigNumber(1)
-    },
-    gasPrice: {
-      decimals: 6,
-      raw: new BigNumber(0),
-      value: new BigNumber(0)
-    },
-    currencyNetworkOfFees: '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18'
+      raw: '1000000000000000000',
+      value: '1'
+    }
   },
   rawTx: {
     from: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',

--- a/tests/e2e/EthWrapper.test.ts
+++ b/tests/e2e/EthWrapper.test.ts
@@ -52,7 +52,7 @@ describe('e2e', () => {
         it('should prepare a deposit tx', async () => {
           await expect(
             tl1.ethWrapper.prepDeposit(ethWrapperAddress, depositAmount)
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
       })
 
@@ -104,7 +104,7 @@ describe('e2e', () => {
               tl2.user.address,
               transferAmount
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
       })
 
@@ -166,7 +166,7 @@ describe('e2e', () => {
         it('should prepare withdraw tx', async () => {
           await expect(
             tl1.ethWrapper.prepWithdraw(ethWrapperAddress, withdrawAmount)
-          ).to.eventually.have.keys('rawTx', 'ethFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
       })
 

--- a/tests/e2e/Exchange.test.ts
+++ b/tests/e2e/Exchange.test.ts
@@ -222,7 +222,7 @@ describe('e2e', () => {
           tl2.exchange.prepTakeOrder(order, 1)
         ).to.eventually.have.keys(
           'rawTx',
-          'ethFees',
+          'txFees',
           'makerMaxFees',
           'makerPath',
           'takerMaxFees',

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -75,9 +75,9 @@ describe('e2e', () => {
       })
 
       it('should give a different nonce after transaction was sent', async () => {
-        const firstNonce = (await identityWallet.getTxInfos(
+        const firstNonce = await relayProvider.getIdentityNonce(
           identityWallet.address
-        )).nonce
+        )
 
         const { rawTx } = await trustlinesNetwork.payment.prepareEth(
           identityWallet.address,
@@ -85,9 +85,9 @@ describe('e2e', () => {
         )
         await trustlinesNetwork.payment.confirm(rawTx)
 
-        const secondNonce = (await identityWallet.getTxInfos(
+        const secondNonce = await relayProvider.getIdentityNonce(
           identityWallet.address
-        )).nonce
+        )
 
         expect(firstNonce).to.equal(1)
         expect(secondNonce).to.equal(2)
@@ -122,7 +122,7 @@ describe('e2e', () => {
       })
 
       it('should relay meta transaction and return a transaction hash', async () => {
-        const rawTx: RawTxObject = {
+        let rawTx: RawTxObject = {
           data: '0x',
           from: identityWallet.address,
           nonce: 1,
@@ -130,12 +130,7 @@ describe('e2e', () => {
           value: 0
         }
 
-        const txFees = await identityWallet.getMetaTxFees(rawTx)
-        rawTx.delegationFees = {
-          baseFee: txFees.baseFee,
-          gasPrice: txFees.gasPrice,
-          currencyNetworkOfFees: txFees.currencyNetworkOfFees
-        }
+        rawTx = await identityWallet.fillFeesAndNonce(rawTx)
 
         const transactionHash = await identityWallet.confirm(rawTx)
         assert.isString(transactionHash)

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -126,8 +126,7 @@ describe('e2e', () => {
           expect(preparedPayment).to.have.all.keys(
             'rawTx',
             'feePayer',
-            'ethFees',
-            'delegationFees',
+            'txFees',
             'maxFees',
             'path'
           )
@@ -143,8 +142,7 @@ describe('e2e', () => {
           expect(preparedPayment).to.have.all.keys(
             'rawTx',
             'feePayer',
-            'ethFees',
-            'delegationFees',
+            'txFees',
             'maxFees',
             'path'
           )
@@ -163,8 +161,7 @@ describe('e2e', () => {
           expect(preparedPayment).to.have.all.keys(
             'rawTx',
             'feePayer',
-            'ethFees',
-            'delegationFees',
+            'txFees',
             'maxFees',
             'path'
           )
@@ -190,15 +187,15 @@ describe('e2e', () => {
               (48000 * 1.2 * 1000) / 1_000_000 + 1
             )
 
-            expect(preparedPayment.delegationFees.raw).to.equal(
+            expect(preparedPayment.txFees.totalFee.raw).to.equal(
               delegationFeeRaw.toString(),
               'Incorrect delegationFees raw'
             )
-            expect(preparedPayment.delegationFees.value).to.equal(
+            expect(preparedPayment.txFees.totalFee.value).to.equal(
               (delegationFeeRaw / 10_000).toString(),
               'Incorrect delegationFees value'
             )
-            expect(preparedPayment.delegationFees.decimals).to.equal(
+            expect(preparedPayment.txFees.totalFee.decimals).to.equal(
               4,
               'Incorrect delegationFees decimals'
             )
@@ -277,7 +274,7 @@ describe('e2e', () => {
         it('should prepare tx for eth transfer', async () => {
           await expect(
             tl1.payment.prepareEth(user2.address, 0.05)
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
       })
 

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -76,7 +76,7 @@ describe('e2e', () => {
               2000,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
 
         it('should prepare raw trustline update request tx in network with DEFAULT interest rates', async () => {
@@ -87,7 +87,7 @@ describe('e2e', () => {
               2000,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
 
         it('should prepare raw trustline update request tx in network with CUSTOM interest rates', async () => {
@@ -103,7 +103,7 @@ describe('e2e', () => {
                 isFrozen: false
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
 
         it('should prepare raw trustline update request tx with freezing', async () => {
@@ -119,7 +119,7 @@ describe('e2e', () => {
                 isFrozen: true
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
       })
 
@@ -203,7 +203,7 @@ describe('e2e', () => {
               networkWithoutInterestRates.address,
               user2.address
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
       })
 
@@ -513,7 +513,7 @@ describe('e2e', () => {
               1250,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
 
         it('should prepare accept tx for network with DEFAULT interest rates', async () => {
@@ -524,7 +524,7 @@ describe('e2e', () => {
               1250,
               1000
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
 
         it('should prepare accept tx for network with CUSTOM interest rates', () => {
@@ -540,7 +540,7 @@ describe('e2e', () => {
                 isFrozen: false
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
 
         it('should prepare accept tx for trustline update with freezing', async () => {
@@ -556,7 +556,7 @@ describe('e2e', () => {
                 isFrozen: true
               }
             )
-          ).to.eventually.have.keys('rawTx', 'ethFees', 'delegationFees')
+          ).to.eventually.have.keys('rawTx', 'txFees')
         })
       })
 
@@ -984,13 +984,18 @@ describe('e2e', () => {
           )
           expect(closeTx).to.have.all.keys([
             'rawTx',
-            'ethFees',
-            'delegationFees',
+            'txFees',
             'maxFees',
             'path'
           ])
           expect(closeTx.path.length).to.equal(0)
-          expect(closeTx.ethFees).to.have.all.keys(['raw', 'value', 'decimals'])
+          expect(closeTx.txFees).to.have.all.keys([
+            'baseFee',
+            'currencyNetworkOfFees',
+            'gasPrice',
+            'gasLimit',
+            'totalFee'
+          ])
           expect(closeTx.maxFees).to.have.all.keys(['raw', 'value', 'decimals'])
         })
 
@@ -1069,7 +1074,7 @@ describe('e2e', () => {
           await wait()
         })
 
-        it('should be possible to prepare a close in the correct direction.', async () => {
+        it('should be possible to prepare a close in the correct direction', async () => {
           // Send the prepare settle to the relay, expecting a valid path exists.
           const closeTx = await tl1.trustline.prepareClose(
             networkWithoutInterestRates.address,
@@ -1077,13 +1082,18 @@ describe('e2e', () => {
           )
           expect(closeTx).to.have.all.keys([
             'rawTx',
-            'ethFees',
-            'delegationFees',
+            'txFees',
             'maxFees',
             'path'
           ])
           expect(closeTx.path).to.include(tl3.user.address)
-          expect(closeTx.ethFees).to.have.all.keys(['raw', 'value', 'decimals'])
+          expect(closeTx.txFees).to.have.all.keys([
+            'baseFee',
+            'currencyNetworkOfFees',
+            'gasPrice',
+            'gasLimit',
+            'totalFee'
+          ])
           expect(closeTx.maxFees).to.have.all.keys(['raw', 'value', 'decimals'])
         })
 

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -142,12 +142,8 @@ export class FakeTLProvider implements TLProvider {
     })
   }
 
-  public async getMetaTxInfos(userAddress: string): Promise<TxInfos> {
-    return Promise.resolve({
-      balance: new BigNumber('0'),
-      gasPrice: new BigNumber('0'),
-      nonce: 1
-    })
+  public async getIdentityNonce(userAddress: string): Promise<number> {
+    return Promise.resolve(123)
   }
 
   public async getMetaTxFees(

--- a/tests/helpers/FakeTLSigner.ts
+++ b/tests/helpers/FakeTLSigner.ts
@@ -8,6 +8,7 @@ import {
   TxInfos
 } from '../../src/typings'
 
+import { BigNumber } from 'bignumber.js'
 import {
   FAKE_AMOUNT,
   FAKE_SIGNED_MSG_HASH,
@@ -78,5 +79,14 @@ export class FakeTLSigner implements TLSigner {
       gasPrice: '0',
       currencyNetworkOfFees: ''
     }
+  }
+
+  public async fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject> {
+    rawTx.nonce = rawTx.nonce || 1
+    rawTx.gasPrice = rawTx.gasPrice || new BigNumber(1)
+    rawTx.baseFee = rawTx.baseFee || new BigNumber(1)
+    rawTx.currencyNetworkOfFees = rawTx.currencyNetworkOfFees || undefined
+    rawTx.totalFee = new BigNumber(1)
+    return rawTx
   }
 }

--- a/tests/unit/Transaction.test.ts
+++ b/tests/unit/Transaction.test.ts
@@ -51,7 +51,7 @@ describe('unit', () => {
           'transfer',
           ['10000', '0', [USER_ADDRESS, COUNTER_PARTY_ADDRESS], EXTRA_DATA]
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'txFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'data',
           'from',
@@ -59,8 +59,10 @@ describe('unit', () => {
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce',
-          'delegationFees'
+          'baseFee',
+          'currencyNetworkOfFees',
+          'totalFee',
+          'nonce'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, CONTRACT_ADDRESS)
@@ -70,29 +72,26 @@ describe('unit', () => {
         assert.instanceOf(rawTxObject.rawTx.gasPrice, BigNumber)
         assert.isNumber(rawTxObject.rawTx.nonce)
         assert.isString(rawTxObject.rawTx.data)
-        assert.hasAllKeys(rawTxObject.ethFees, ['decimals', 'raw', 'value'])
-        assert.equal(rawTxObject.ethFees.decimals, 18)
-        assert.instanceOf(rawTxObject.ethFees.raw, BigNumber)
-        assert.instanceOf(rawTxObject.ethFees.value, BigNumber)
-        assert.hasAllKeys(rawTxObject.rawTx.delegationFees, [
+        assert.hasAllKeys(rawTxObject.txFees, [
+          'totalFee',
           'baseFee',
-          'gasPrice',
-          'currencyNetworkOfFees'
+          'currencyNetworkOfFees',
+          'gasLimit',
+          'gasPrice'
         ])
-        assert.isString(rawTxObject.rawTx.delegationFees.currencyNetworkOfFees)
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.baseFee, BigNumber)
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.gasPrice, BigNumber)
+        assert.equal(rawTxObject.txFees.totalFee.decimals, 18)
+        assert.isString(rawTxObject.txFees.totalFee.raw)
+        assert.isString(rawTxObject.txFees.totalFee.value)
+        assert.isString(rawTxObject.txFees.baseFee.raw)
+        assert.isString(rawTxObject.txFees.baseFee.value)
+        assert.isString(rawTxObject.txFees.gasPrice.raw)
+        assert.isString(rawTxObject.txFees.gasPrice.value)
       })
 
       it('should prepare a transaction object for calling a function with options', async () => {
         const CUSTOM_GAS_LIMIT = 10000000
         const CUSTOM_GAS_PRICE = 1
         const CUSTOM_VALUE = 123
-        const CUSTOM_DELEGATION_FEES = {
-          baseFee: new BigNumber(CUSTOM_VALUE),
-          gasPrice: new BigNumber(CUSTOM_GAS_PRICE),
-          currencyNetworkOfFees: CONTRACT_ADDRESS
-        }
         const rawTxObject = await transaction.prepareContractTransaction(
           USER_ADDRESS,
           CONTRACT_ADDRESS,
@@ -103,10 +102,11 @@ describe('unit', () => {
             gasLimit: new BigNumber(CUSTOM_GAS_LIMIT),
             gasPrice: new BigNumber(CUSTOM_GAS_PRICE),
             value: new BigNumber(CUSTOM_VALUE),
-            delegationFees: CUSTOM_DELEGATION_FEES
+            baseFee: new BigNumber(CUSTOM_VALUE),
+            currencyNetworkOfFees: CONTRACT_ADDRESS
           }
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'txFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'data',
           'from',
@@ -114,8 +114,10 @@ describe('unit', () => {
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce',
-          'delegationFees'
+          'baseFee',
+          'currencyNetworkOfFees',
+          'totalFee',
+          'nonce'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, CONTRACT_ADDRESS)
@@ -136,28 +138,34 @@ describe('unit', () => {
         )
         assert.isNumber(rawTxObject.rawTx.nonce)
         assert.isString(rawTxObject.rawTx.data)
-        assert.hasAllKeys(rawTxObject.ethFees, ['decimals', 'raw', 'value'])
-        assert.equal(rawTxObject.ethFees.decimals, 18)
-        assert.instanceOf(rawTxObject.ethFees.raw, BigNumber)
-        assert.instanceOf(rawTxObject.ethFees.value, BigNumber)
-        assert.hasAllKeys(rawTxObject.rawTx.delegationFees, [
+        assert.hasAllKeys(rawTxObject.txFees.totalFee, [
+          'decimals',
+          'raw',
+          'value'
+        ])
+        assert.equal(
+          rawTxObject.txFees.totalFee.decimals,
+          2,
+          'Should use the decimals of the currency network'
+        )
+        assert.isString(rawTxObject.txFees.totalFee.raw)
+        assert.isString(rawTxObject.txFees.totalFee.value)
+        assert.hasAllKeys(rawTxObject.txFees, [
           'baseFee',
           'gasPrice',
+          'gasLimit',
+          'totalFee',
           'currencyNetworkOfFees'
         ])
-        assert.isString(rawTxObject.rawTx.delegationFees.currencyNetworkOfFees)
+        assert.isString(rawTxObject.txFees.currencyNetworkOfFees)
+        assert.equal(rawTxObject.txFees.currencyNetworkOfFees, CONTRACT_ADDRESS)
+        assert.isString(rawTxObject.txFees.baseFee.raw)
+        assert.isString(rawTxObject.txFees.baseFee.value)
+        assert.equal(rawTxObject.txFees.baseFee.raw, CUSTOM_VALUE.toString())
+        assert.isString(rawTxObject.txFees.gasPrice.raw)
+        assert.isString(rawTxObject.txFees.gasPrice.value)
         assert.equal(
-          rawTxObject.rawTx.delegationFees.currencyNetworkOfFees,
-          CONTRACT_ADDRESS
-        )
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.baseFee, BigNumber)
-        assert.equal(
-          rawTxObject.rawTx.delegationFees.baseFee.toString(),
-          CUSTOM_VALUE.toString()
-        )
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.gasPrice, BigNumber)
-        assert.equal(
-          rawTxObject.rawTx.delegationFees.gasPrice.toString(),
+          rawTxObject.txFees.gasPrice.raw,
           CUSTOM_GAS_PRICE.toString()
         )
       })
@@ -170,15 +178,17 @@ describe('unit', () => {
           COUNTER_PARTY_ADDRESS,
           new BigNumber('1')
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'txFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'from',
           'to',
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce',
-          'delegationFees'
+          'baseFee',
+          'currencyNetworkOfFees',
+          'totalFee',
+          'nonce'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, COUNTER_PARTY_ADDRESS)
@@ -187,18 +197,20 @@ describe('unit', () => {
         assert.instanceOf(rawTxObject.rawTx.gasLimit, BigNumber)
         assert.instanceOf(rawTxObject.rawTx.gasPrice, BigNumber)
         assert.isNumber(rawTxObject.rawTx.nonce)
-        assert.hasAllKeys(rawTxObject.ethFees, ['decimals', 'raw', 'value'])
-        assert.equal(rawTxObject.ethFees.decimals, 18)
-        assert.instanceOf(rawTxObject.ethFees.raw, BigNumber)
-        assert.instanceOf(rawTxObject.ethFees.value, BigNumber)
-        assert.hasAllKeys(rawTxObject.rawTx.delegationFees, [
+        assert.hasAllKeys(rawTxObject.txFees, [
+          'totalFee',
           'baseFee',
-          'gasPrice',
-          'currencyNetworkOfFees'
+          'currencyNetworkOfFees',
+          'gasLimit',
+          'gasPrice'
         ])
-        assert.isString(rawTxObject.rawTx.delegationFees.currencyNetworkOfFees)
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.baseFee, BigNumber)
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.gasPrice, BigNumber)
+        assert.equal(rawTxObject.txFees.totalFee.decimals, 18)
+        assert.isString(rawTxObject.txFees.totalFee.raw)
+        assert.isString(rawTxObject.txFees.totalFee.value)
+        assert.isString(rawTxObject.txFees.baseFee.raw)
+        assert.isString(rawTxObject.txFees.baseFee.value)
+        assert.isString(rawTxObject.txFees.gasPrice.raw)
+        assert.isString(rawTxObject.txFees.gasPrice.value)
       })
 
       it('should prepare a transaction object for transferring eth with options', async () => {
@@ -217,18 +229,21 @@ describe('unit', () => {
           {
             gasLimit: new BigNumber(CUSTOM_GAS_LIMIT),
             gasPrice: new BigNumber(CUSTOM_GAS_PRICE),
-            delegationFees: CUSTOM_DELEGATION_FEES
+            baseFee: new BigNumber(CUSTOM_VALUE),
+            currencyNetworkOfFees: CONTRACT_ADDRESS
           }
         )
-        assert.hasAllKeys(rawTxObject, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(rawTxObject, ['rawTx', 'txFees'])
         assert.hasAllKeys(rawTxObject.rawTx, [
           'from',
           'to',
           'value',
           'gasLimit',
           'gasPrice',
-          'nonce',
-          'delegationFees'
+          'baseFee',
+          'currencyNetworkOfFees',
+          'totalFee',
+          'nonce'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
         assert.equal(rawTxObject.rawTx.to, COUNTER_PARTY_ADDRESS)
@@ -248,28 +263,34 @@ describe('unit', () => {
           CUSTOM_GAS_PRICE.toString()
         )
         assert.isNumber(rawTxObject.rawTx.nonce)
-        assert.hasAllKeys(rawTxObject.ethFees, ['decimals', 'raw', 'value'])
-        assert.equal(rawTxObject.ethFees.decimals, 18)
-        assert.instanceOf(rawTxObject.ethFees.raw, BigNumber)
-        assert.instanceOf(rawTxObject.ethFees.value, BigNumber)
-        assert.hasAllKeys(rawTxObject.rawTx.delegationFees, [
+        assert.hasAllKeys(rawTxObject.txFees.totalFee, [
+          'decimals',
+          'raw',
+          'value'
+        ])
+        assert.equal(
+          rawTxObject.txFees.totalFee.decimals,
+          2,
+          'Should use the decimals of the currency network'
+        )
+        assert.isString(rawTxObject.txFees.totalFee.raw)
+        assert.isString(rawTxObject.txFees.totalFee.value)
+        assert.hasAllKeys(rawTxObject.txFees, [
           'baseFee',
           'gasPrice',
+          'gasLimit',
+          'totalFee',
           'currencyNetworkOfFees'
         ])
-        assert.isString(rawTxObject.rawTx.delegationFees.currencyNetworkOfFees)
+        assert.isString(rawTxObject.txFees.currencyNetworkOfFees)
+        assert.equal(rawTxObject.txFees.currencyNetworkOfFees, CONTRACT_ADDRESS)
+        assert.isString(rawTxObject.txFees.baseFee.raw)
+        assert.isString(rawTxObject.txFees.baseFee.value)
+        assert.equal(rawTxObject.txFees.baseFee.raw, CUSTOM_VALUE.toString())
+        assert.isString(rawTxObject.txFees.gasPrice.raw)
+        assert.isString(rawTxObject.txFees.gasPrice.value)
         assert.equal(
-          rawTxObject.rawTx.delegationFees.currencyNetworkOfFees,
-          CONTRACT_ADDRESS
-        )
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.baseFee, BigNumber)
-        assert.equal(
-          rawTxObject.rawTx.delegationFees.baseFee.toString(),
-          CUSTOM_VALUE.toString()
-        )
-        assert.instanceOf(rawTxObject.rawTx.delegationFees.gasPrice, BigNumber)
-        assert.equal(
-          rawTxObject.rawTx.delegationFees.gasPrice.toString(),
+          rawTxObject.txFees.gasPrice.raw,
           CUSTOM_GAS_PRICE.toString()
         )
       })

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -70,7 +70,7 @@ describe('unit', () => {
           100,
           200
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'txFees'])
       })
 
       it('should return a transaction object with specified interests', async () => {
@@ -85,7 +85,7 @@ describe('unit', () => {
             isFrozen: false
           }
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'txFees'])
       })
 
       it('should return a transaction object with specified interests, with default isFrozen value', async () => {
@@ -99,7 +99,7 @@ describe('unit', () => {
             interestRateReceived: 0.02
           }
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'txFees'])
       })
     })
 
@@ -113,7 +113,7 @@ describe('unit', () => {
           100,
           200
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'txFees'])
       })
 
       it('should return a transaction object with specified interests', async () => {
@@ -128,7 +128,7 @@ describe('unit', () => {
             isFrozen: false
           }
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'txFees'])
       })
     })
 
@@ -140,7 +140,7 @@ describe('unit', () => {
           FAKE_NETWORK.address,
           '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18'
         )
-        assert.hasAllKeys(tx, ['rawTx', 'ethFees', 'delegationFees'])
+        assert.hasAllKeys(tx, ['rawTx', 'txFees'])
       })
     })
 
@@ -257,13 +257,7 @@ describe('unit', () => {
           FAKE_NETWORK.address,
           TL_WALLET_DATA.address
         )
-        assert.hasAllKeys(closeTx, [
-          'ethFees',
-          'maxFees',
-          'path',
-          'rawTx',
-          'delegationFees'
-        ])
+        assert.hasAllKeys(closeTx, ['txFees', 'maxFees', 'path', 'rawTx'])
       })
     })
   })


### PR DESCRIPTION
- Make transaction (mostly) independant of whether we use identity wallet or not
- Return txFee object with all relevant information for mobileApp when preping a tx
- Use gas limits in transactions