### PR TITLE
Revert "Add new event identifier field"

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -105,7 +105,6 @@ export interface EventFilterOptions {
 }
 
 export interface BlockchainEvent {
-  id: string
   type: string
   timestamp: number
   blockNumber: number

--- a/tests/e2e/Exchange.test.ts
+++ b/tests/e2e/Exchange.test.ts
@@ -329,8 +329,7 @@ describe('e2e', () => {
         'transactionId',
         'from',
         'to',
-        'direction',
-        'id'
+        'direction'
       ]
       const fillEventKeys = exEventKeys.concat([
         'filledMakerAmount',


### PR DESCRIPTION
This reverts commit 8207cbbfb1f168a5b74ecb2d6f95104a2792a8d6.

**This is just to fix the end-to-end tests again.**