### PR TITLE
Feature/delegation fees null when empty

### DIFF
--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -165,6 +165,7 @@ export class Transaction {
       gasLimit: utils.formatToAmount(rawTx.gasLimit, 0),
       baseFee: utils.formatToAmount(rawTx.baseFee, feeDecimals),
       totalFee: utils.formatToAmount(rawTx.totalFee, feeDecimals),
+      feeRecipient: rawTx.feeRecipient || undefined,
       currencyNetworkOfFees: rawTx.currencyNetworkOfFees || undefined
     }
   }

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -490,7 +490,6 @@ export class Trustline {
       }
     )
 
-    // Value taken from contracts gas tests
     return {
       txFees,
       maxFees,

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -65,21 +65,10 @@ export class RelayProvider extends Provider implements TLProvider {
         metaTransaction
       }
     )
-    let baseFee = '0'
-    let gasPrice = '0'
-    let currencyNetworkOfFees = '0x' + '0'.repeat(40)
-    if (potentialDelegationFees.length) {
-      // For now just get the first possible fee given by the relay server
-      // Could be changed later to show the possible fees to the user and let it decide
-      baseFee = potentialDelegationFees[0].baseFee
-      gasPrice = potentialDelegationFees[0].gasPrice
-      currencyNetworkOfFees = potentialDelegationFees[0].currencyNetworkOfFees
+    if (potentialDelegationFees.length === 0) {
+      throw new Error('This relay provider does not accept any fees.')
     }
-    return {
-      baseFee,
-      gasPrice,
-      currencyNetworkOfFees
-    }
+    return potentialDelegationFees[0]
   }
 
   public async getMetaTxStatus(

--- a/src/signers/TLSigner.ts
+++ b/src/signers/TLSigner.ts
@@ -3,7 +3,8 @@ import {
   MetaTransactionFees,
   RawTxObject,
   Signature,
-  TransactionStatusObject
+  TransactionStatusObject,
+  TxObjectRaw
 } from '../typings'
 
 /**
@@ -16,7 +17,7 @@ export interface TLSigner {
   signMessage(message: string | ArrayLike<number>): Promise<Signature>
   hashTx(rawTx: RawTxObject): Promise<string>
   confirm(rawTx: RawTxObject): Promise<string>
-  fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject>
+  prepareTransaction(rawTx: RawTxObject): Promise<TxObjectRaw>
   getTxStatus(txHash: string | RawTxObject): Promise<TransactionStatusObject>
   getMetaTxFees(rawTx: RawTxObject): Promise<MetaTransactionFees>
 }

--- a/src/signers/Web3Signer.ts
+++ b/src/signers/Web3Signer.ts
@@ -12,7 +12,8 @@ import {
   RawTxObject,
   Signature,
   TransactionStatusObject,
-  TxInfos
+  TxInfos,
+  TxObjectRaw
 } from '../typings'
 
 /**
@@ -141,13 +142,25 @@ export class Web3Signer implements TLSigner {
     return { balance, gasPrice, nonce }
   }
 
-  public async fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject> {
+  public async prepareTransaction(rawTx: RawTxObject): Promise<TxObjectRaw> {
     const { gasPrice, nonce } = await this.getTxInfos(this.address)
-    rawTx.gasPrice = gasPrice
-    rawTx.nonce = nonce
+
+    rawTx.gasPrice = rawTx.gasPrice || gasPrice
     rawTx.baseFee = new BigNumber(0)
     rawTx.totalFee = new BigNumber(rawTx.gasPrice).multipliedBy(rawTx.gasLimit)
-    return rawTx
+    rawTx.nonce = nonce
+
+    const txFees = {
+      gasPrice: rawTx.gasPrice,
+      gasLimit: rawTx.gasLimit,
+      baseFee: rawTx.baseFee,
+      totalFee: rawTx.totalFee
+    }
+
+    return {
+      rawTx,
+      txFees
+    }
   }
 
   public async getTxStatus(

--- a/src/signers/Web3Signer.ts
+++ b/src/signers/Web3Signer.ts
@@ -160,6 +160,7 @@ export class Web3Signer implements TLSigner {
     return {
       baseFee: '0',
       gasPrice: '0',
+      feeRecipient: '',
       currencyNetworkOfFees: ''
     }
   }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -258,6 +258,7 @@ export interface RawTxObject {
   gasLimit?: number | string | BigNumber
   gasPrice?: number | string | BigNumber
   totalFee?: number | string | BigNumber
+  feeRecipient?: string
   currencyNetworkOfFees?: string
 }
 
@@ -282,6 +283,7 @@ export interface MetaTransaction {
 export interface MetaTransactionFees {
   baseFee: string
   gasPrice: string
+  feeRecipient: string
   currencyNetworkOfFees: string
 }
 
@@ -349,6 +351,7 @@ export interface TxFeesAmounts {
   gasLimit: Amount
   baseFee: Amount
   totalFee: Amount
+  feeRecipient?: string
   currencyNetworkOfFees?: string
 }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -248,6 +248,11 @@ export interface TxObjectInternal {
   txFees: TxFeesAmounts
 }
 
+export interface TxObjectRaw {
+  rawTx: RawTxObject
+  txFees: TxFeesRaw
+}
+
 export interface RawTxObject {
   from: string
   to?: string
@@ -344,6 +349,15 @@ export interface TxInfos {
    * Transaction count of given user address
    */
   nonce: number
+}
+
+export interface TxFeesRaw {
+  gasPrice: number | string | BigNumber
+  gasLimit: number | string | BigNumber
+  baseFee: number | string | BigNumber
+  totalFee: number | string | BigNumber
+  feeRecipient?: string
+  currencyNetworkOfFees?: string
 }
 
 export interface TxFeesAmounts {

--- a/src/wallets/EthersWallet.ts
+++ b/src/wallets/EthersWallet.ts
@@ -18,7 +18,8 @@ import {
   MetaTransactionFees,
   RawTxObject,
   Signature,
-  TransactionStatusObject
+  TransactionStatusObject,
+  TxObjectRaw
 } from '../typings'
 
 /**
@@ -287,14 +288,25 @@ export class EthersWallet implements TLWallet {
     throw new Error('Method not implemented.')
   }
 
-  public async fillFeesAndNonce(rawTx: RawTxObject): Promise<RawTxObject> {
+  public async prepareTransaction(rawTx: RawTxObject): Promise<TxObjectRaw> {
     const { gasPrice, nonce } = await this.provider.getTxInfos(this.address)
+
     rawTx.gasPrice = rawTx.gasPrice || gasPrice
     rawTx.baseFee = new BigNumber(0)
     rawTx.totalFee = new BigNumber(rawTx.gasPrice).multipliedBy(rawTx.gasLimit)
     rawTx.nonce = nonce
 
-    return rawTx
+    const txFees = {
+      gasPrice: rawTx.gasPrice,
+      gasLimit: rawTx.gasLimit,
+      baseFee: rawTx.baseFee,
+      totalFee: rawTx.totalFee
+    }
+
+    return {
+      rawTx,
+      txFees
+    }
   }
 
   public async getTxStatus(

--- a/src/wallets/EthersWallet.ts
+++ b/src/wallets/EthersWallet.ts
@@ -308,6 +308,7 @@ export class EthersWallet implements TLWallet {
     return {
       baseFee: '0',
       gasPrice: '0',
+      feeRecipient: '',
       currencyNetworkOfFees: ''
     }
   }

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -341,6 +341,7 @@ export class IdentityWallet implements TLWallet {
       rawTx.gasPrice,
       rawTx.gasLimit
     )
+    rawTx.feeRecipient = rawTx.feeRecipient || metaTxFees.feeRecipient
     rawTx.currencyNetworkOfFees =
       rawTx.currencyNetworkOfFees || metaTxFees.currencyNetworkOfFees
 

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -20,12 +20,10 @@ import {
   wait
 } from '../Fixtures'
 
-import { FeePayer, RawTxObject, TransactionStatus } from '../../src/typings'
-import utils from '../../src/utils'
+import { FeePayer, RawTxObject } from '../../src/typings'
 
 import { TLNetwork } from '../../src/TLNetwork'
 
-import { id } from 'ethers/utils'
 import { TLProvider } from '../../src/providers/TLProvider'
 
 chai.use(chaiAsPromised)
@@ -240,7 +238,8 @@ describe('e2e', () => {
         expect(metaTransactionFees).to.have.all.keys(
           'baseFee',
           'gasPrice',
-          'currencyNetworkOfFees'
+          'currencyNetworkOfFees',
+          'feeRecipient'
         )
         expect(metaTransactionFees.baseFee).to.equal('1')
         expect(metaTransactionFees.gasPrice).to.equal('1000')

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -129,7 +129,7 @@ describe('e2e', () => {
           value: 0
         }
 
-        rawTx = await identityWallet.fillFeesAndNonce(rawTx)
+        rawTx = (await identityWallet.prepareTransaction(rawTx)).rawTx
 
         const transactionHash = await identityWallet.confirm(rawTx)
         assert.isString(transactionHash)

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -3,6 +3,7 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
+import { AddressZero } from 'ethers/constants'
 import { TLNetwork } from '../../src/TLNetwork'
 import { FeePayer, PathRaw, TLWalletData } from '../../src/typings'
 import utils from '../../src/utils'
@@ -190,6 +191,20 @@ describe('e2e', () => {
               expectedGasLimit
             )
 
+            expect(preparedPayment.txFees).to.have.all.keys(
+              'gasPrice',
+              'gasLimit',
+              'baseFee',
+              'totalFee',
+              'feeRecipient',
+              'currencyNetworkOfFees'
+            )
+            expect(preparedPayment.txFees.feeRecipient).to.not.equal(
+              AddressZero
+            )
+            expect(preparedPayment.txFees.currencyNetworkOfFees).to.not.equal(
+              AddressZero
+            )
             expect(preparedPayment.txFees.totalFee.raw).to.equal(
               delegationFeeRaw.toString(),
               'Incorrect delegationFees raw'
@@ -203,9 +218,6 @@ describe('e2e', () => {
               'Incorrect delegationFees decimals'
             )
             expect(preparedPayment.txFees.baseFee.raw).to.equal('1')
-            expect(preparedPayment.txFees.currencyNetworkOfFees).to.not.equal(
-              '0x' + '0'.repeat(40)
-            )
             expect(preparedPayment.txFees.gasPrice.raw).to.equal('1000')
             expect(preparedPayment.txFees.gasLimit.raw).to.equal(
               expectedGasLimit.toString()
@@ -221,6 +233,10 @@ describe('e2e', () => {
 
             const expectedGasLimit = tl1.payment.calculateTransferGasLimit(2)
 
+            expect(preparedPayment).to.not.have.keys(
+              'feeRecipient',
+              'currencyNetworkOfFees'
+            )
             expect(preparedPayment.txFees.gasPrice.raw).to.equal('0')
             expect(preparedPayment.txFees.totalFee.raw).to.equal('0')
             expect(preparedPayment.txFees.totalFee.value).to.equal('0')

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -988,9 +988,8 @@ describe('e2e', () => {
             'path'
           ])
           expect(closeTx.path.length).to.equal(0)
-          expect(closeTx.txFees).to.have.all.keys([
+          expect(closeTx.txFees).to.contain.keys([
             'baseFee',
-            'currencyNetworkOfFees',
             'gasPrice',
             'gasLimit',
             'totalFee'
@@ -1086,9 +1085,8 @@ describe('e2e', () => {
             'path'
           ])
           expect(closeTx.path).to.include(tl3.user.address)
-          expect(closeTx.txFees).to.have.all.keys([
+          expect(closeTx.txFees).to.contain.keys([
             'baseFee',
-            'currencyNetworkOfFees',
             'gasPrice',
             'gasLimit',
             'totalFee'

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -15,6 +15,7 @@ import {
   FAKE_USER_ADDRESSES
 } from '../Fixtures'
 
+import { AddressZero } from 'ethers/constants'
 import {
   Amount,
   MetaTransaction,
@@ -155,6 +156,7 @@ export class FakeTLProvider implements TLProvider {
     return {
       baseFee: '0',
       gasPrice: '0',
+      feeRecipient: AddressZero,
       currencyNetworkOfFees: metaTransaction.currencyNetworkOfFees
     }
   }

--- a/tests/helpers/FakeTLSigner.ts
+++ b/tests/helpers/FakeTLSigner.ts
@@ -86,6 +86,7 @@ export class FakeTLSigner implements TLSigner {
     return {
       baseFee: '0',
       gasPrice: '0',
+      feeRecipient: '',
       currencyNetworkOfFees: ''
     }
   }

--- a/tests/helpers/FakeTLSigner.ts
+++ b/tests/helpers/FakeTLSigner.ts
@@ -5,7 +5,8 @@ import {
   MetaTransactionFees,
   RawTxObject,
   Signature,
-  TxInfos
+  TxInfos,
+  TxObjectRaw
 } from '../../src/typings'
 
 import { BigNumber } from 'bignumber.js'
@@ -88,6 +89,29 @@ export class FakeTLSigner implements TLSigner {
       gasPrice: '0',
       feeRecipient: '',
       currencyNetworkOfFees: ''
+    }
+  }
+
+  public async prepareTransaction(rawTx: RawTxObject): Promise<TxObjectRaw> {
+    rawTx.nonce = rawTx.nonce || 1
+    rawTx.gasPrice = rawTx.gasPrice || new BigNumber(1)
+    rawTx.baseFee = rawTx.baseFee || new BigNumber(1)
+    rawTx.feeRecipient = rawTx.feeRecipient || undefined
+    rawTx.currencyNetworkOfFees = rawTx.currencyNetworkOfFees || undefined
+    rawTx.totalFee = new BigNumber(1)
+
+    const txFees = {
+      gasPrice: rawTx.gasPrice,
+      gasLimit: rawTx.gasLimit,
+      baseFee: rawTx.baseFee,
+      totalFee: rawTx.totalFee,
+      currencyNetworkOfFees: rawTx.currencyNetworkOfFees || undefined,
+      feeRecipient: rawTx.feeRecipient || undefined
+    }
+
+    return {
+      rawTx,
+      txFees
     }
   }
 

--- a/tests/helpers/FakeTLSigner.ts
+++ b/tests/helpers/FakeTLSigner.ts
@@ -95,6 +95,7 @@ export class FakeTLSigner implements TLSigner {
     rawTx.nonce = rawTx.nonce || 1
     rawTx.gasPrice = rawTx.gasPrice || new BigNumber(1)
     rawTx.baseFee = rawTx.baseFee || new BigNumber(1)
+    rawTx.feeRecipient = rawTx.feeRecipient || undefined
     rawTx.currencyNetworkOfFees = rawTx.currencyNetworkOfFees || undefined
     rawTx.totalFee = new BigNumber(1)
     return rawTx

--- a/tests/unit/Transaction.test.ts
+++ b/tests/unit/Transaction.test.ts
@@ -60,8 +60,9 @@ describe('unit', () => {
           'gasLimit',
           'gasPrice',
           'baseFee',
-          'currencyNetworkOfFees',
           'totalFee',
+          'feeRecipient',
+          'currencyNetworkOfFees',
           'nonce'
         ])
         assert.equal(rawTxObject.rawTx.from, USER_ADDRESS)
@@ -75,8 +76,9 @@ describe('unit', () => {
         assert.hasAllKeys(rawTxObject.txFees, [
           'totalFee',
           'baseFee',
-          'currencyNetworkOfFees',
           'gasLimit',
+          'feeRecipient',
+          'currencyNetworkOfFees',
           'gasPrice'
         ])
         assert.equal(rawTxObject.txFees.totalFee.decimals, 18)
@@ -115,6 +117,7 @@ describe('unit', () => {
           'gasLimit',
           'gasPrice',
           'baseFee',
+          'feeRecipient',
           'currencyNetworkOfFees',
           'totalFee',
           'nonce'
@@ -155,6 +158,7 @@ describe('unit', () => {
           'gasPrice',
           'gasLimit',
           'totalFee',
+          'feeRecipient',
           'currencyNetworkOfFees'
         ])
         assert.isString(rawTxObject.txFees.currencyNetworkOfFees)
@@ -186,6 +190,7 @@ describe('unit', () => {
           'gasLimit',
           'gasPrice',
           'baseFee',
+          'feeRecipient',
           'currencyNetworkOfFees',
           'totalFee',
           'nonce'
@@ -200,6 +205,7 @@ describe('unit', () => {
         assert.hasAllKeys(rawTxObject.txFees, [
           'totalFee',
           'baseFee',
+          'feeRecipient',
           'currencyNetworkOfFees',
           'gasLimit',
           'gasPrice'
@@ -241,6 +247,7 @@ describe('unit', () => {
           'gasLimit',
           'gasPrice',
           'baseFee',
+          'feeRecipient',
           'currencyNetworkOfFees',
           'totalFee',
           'nonce'
@@ -280,6 +287,7 @@ describe('unit', () => {
           'gasPrice',
           'gasLimit',
           'totalFee',
+          'feeRecipient',
           'currencyNetworkOfFees'
         ])
         assert.isString(rawTxObject.txFees.currencyNetworkOfFees)


### PR DESCRIPTION
Meta transactions now use the feeRecipient field filling it with what the relay gives
delegation fees will have undefined currencyNetwork when none are given by the relay.

goes with https://github.com/trustlines-protocol/relay/pull/457
closes https://github.com/trustlines-protocol/clientlib/issues/324