### PR TITLE
Change gas limits as taken from new contracts calculations

### DIFF
--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -21,13 +21,13 @@ import {
 import { CurrencyNetwork } from './CurrencyNetwork'
 
 const ETH_DECIMALS = 18
-export const GAS_LIMIT_MULTIPLIER = 1.3
+export const GAS_LIMIT_MULTIPLIER = 1.2
 // Value taken from the contracts gas tests
-export const GAS_COST_IDENTITY_OVERHEAD = new BigNumber(27_000)
-export const GAS_COST_VALUE_TRANSACTION = new BigNumber(21_000)
-  .plus(GAS_COST_IDENTITY_OVERHEAD.multipliedBy(GAS_LIMIT_MULTIPLIER))
+export const GAS_LIMIT_IDENTITY_OVERHEAD = new BigNumber(27_000)
+export const GAS_LIMIT_VALUE_TRANSACTION = new BigNumber(21_000)
+  .plus(GAS_LIMIT_IDENTITY_OVERHEAD.multipliedBy(GAS_LIMIT_MULTIPLIER))
   .integerValue(BigNumber.ROUND_DOWN)
-export const GAS_COST_DEFAULT_CONTRACT_TRANSACTION = new BigNumber(600_000)
+export const GAS_LIMIT_DEFAULT_CONTRACT_TRANSACTION = new BigNumber(600_000)
 
 /**
  * The Transaction class contains functions that are needed for Ethereum transactions.
@@ -76,7 +76,7 @@ export class Transaction {
       data: abi.functions[functionName].encode(args),
       from: userAddress,
       to: contractAddress,
-      gasLimit: options.gasLimit || GAS_COST_DEFAULT_CONTRACT_TRANSACTION,
+      gasLimit: options.gasLimit || GAS_LIMIT_DEFAULT_CONTRACT_TRANSACTION,
       gasPrice: options.gasPrice || undefined,
       baseFee: options.baseFee || undefined,
       currencyNetworkOfFees: options.currencyNetworkOfFees || undefined,
@@ -112,7 +112,7 @@ export class Transaction {
     let rawTx: RawTxObject = {
       from: senderAddress,
       to: receiverAddress,
-      gasLimit: options.gasLimit || GAS_COST_VALUE_TRANSACTION,
+      gasLimit: options.gasLimit || GAS_LIMIT_VALUE_TRANSACTION,
       gasPrice: options.gasPrice || undefined,
       baseFee: options.baseFee || undefined,
       currencyNetworkOfFees: options.currencyNetworkOfFees || undefined,
@@ -153,7 +153,7 @@ export class Transaction {
     rawTx: RawTxObject
   ): Promise<TxFeesAmounts> {
     // 18 decimals for regular tx fees in ether
-    let feeDecimals = 18
+    let feeDecimals = ETH_DECIMALS
     if (rawTx.currencyNetworkOfFees) {
       feeDecimals = (await this.currencyNetwork.getDecimals(
         rawTx.currencyNetworkOfFees

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,10 @@ import { Observer } from 'rxjs/Observer'
 import JsonRPC from 'simple-jsonrpc-js'
 import NodeWebSocket from 'ws'
 
-import { GAS_COST_IDENTITY_OVERHEAD, GAS_LIMIT_MULTIPLIER } from './Transaction'
+import {
+  GAS_LIMIT_IDENTITY_OVERHEAD,
+  GAS_LIMIT_MULTIPLIER
+} from './Transaction'
 import {
   Amount,
   AmountInternal,
@@ -303,19 +306,6 @@ export const calculateDelegationFees = (
   )
 }
 
-const GAS_COST_TRANSFER_BASE = new BigNumber(48000)
-const GAS_COST_TRANSFER_PER_MEDIATOR = new BigNumber(18000)
-
-export const calculateTransferGasLimit = (pathLength: number): BigNumber => {
-  // Values taken from the contracts repository gas tests
-  const mediators = pathLength - 2
-  return GAS_COST_TRANSFER_BASE.plus(
-    GAS_COST_TRANSFER_PER_MEDIATOR.multipliedBy(mediators)
-  )
-    .plus(GAS_COST_IDENTITY_OVERHEAD)
-    .multipliedBy(GAS_LIMIT_MULTIPLIER)
-}
-
 // This constant is taken from the identity contracts where the gas price is divided before used in fee calculation
 export const DELEGATION_GAS_PRICE_DIVISOR = 1_000_000
 
@@ -517,7 +507,6 @@ export default {
   calcValue,
   calculateDelegationFees,
   calculateDelegationFeesAmount,
-  calculateTransferGasLimit,
   checkAddress,
   convertEthToWei,
   convertToAmount,

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -183,7 +183,7 @@ describe('e2e', () => {
               2.25
             )
 
-            const expectedGasLimit = utils.calculateTransferGasLimit(2)
+            const expectedGasLimit = tl1.payment.calculateTransferGasLimit(2)
             const delegationFeeRaw = utils.calculateDelegationFees(
               1,
               1_000,
@@ -219,7 +219,7 @@ describe('e2e', () => {
               2.25
             )
 
-            const expectedGasLimit = utils.calculateTransferGasLimit(2)
+            const expectedGasLimit = tl1.payment.calculateTransferGasLimit(2)
 
             expect(preparedPayment.txFees.gasPrice.raw).to.equal('0')
             expect(preparedPayment.txFees.totalFee.raw).to.equal('0')


### PR DESCRIPTION
The previous gas limits were actually gas costs, so they were too
low and would fail in certain case.