### PR TITLE
Improve buildUrl function

### DIFF
--- a/src/Contact.ts
+++ b/src/Contact.ts
@@ -1,7 +1,7 @@
 import { TLProvider } from './providers/TLProvider'
 import { User } from './User'
 
-import utils from './utils'
+import utils, { defaultBaseUrl } from './utils'
 
 export class Contact {
   private user: User
@@ -20,15 +20,23 @@ export class Contact {
   /**
    * Creates sharable contact link.
    * @param address Address of contact to share.
-   * @param username Name of contact to share.
-   * @param customBase Optional custom base for link. Default `trustlines://`.
+   * @param options Optional
+   *        options[key] - additional params that will be appended
+   *        options.name - optional user name
+   *        options.subject - optional message for the recipient of the request
+   *        options.customBase - Optional custom base for link. Defaults to `trustlines://`.
    */
   public createLink(
     address: string,
-    username: string,
-    customBase?: string
+    options?: {
+      [key: string]: string
+      subject?: string
+      name?: string
+      customBase?: string
+    }
   ): string {
-    const params = ['contact', address, username]
-    return utils.createLink(params, customBase)
+    const path = ['contact', address]
+    const { customBase = defaultBaseUrl, ...rest } = options
+    return utils.buildUrl(customBase, { path, query: rest })
   }
 }

--- a/src/EthWrapper.ts
+++ b/src/EthWrapper.ts
@@ -176,7 +176,7 @@ export class EthWrapper {
     const { type, fromBlock } = filter
     const baseUrl = `tokens/${ethWrapperAddress}/users/${await this.user.getAddress()}/events`
     const events = await this.provider.fetchEndpoint<AnyTokenEventRaw[]>(
-      utils.buildUrl(baseUrl, { type, fromBlock })
+      utils.buildUrl(baseUrl, { query: { type, fromBlock } })
     )
     return events.map(event => utils.formatEvent(event, ETH_DECIMALS, 0))
   }

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -69,7 +69,7 @@ export class Event {
     } = {}
   ): Promise<T[]> {
     const baseUrl = `networks/${networkAddress}/users/${await this.user.getAddress()}/events`
-    const parameterUrl = utils.buildUrl(baseUrl, filter)
+    const parameterUrl = utils.buildUrl(baseUrl, { query: filter })
     const [
       events,
       { networkDecimals, interestRateDecimals }
@@ -96,7 +96,7 @@ export class Event {
    */
   public async getAll(filter: EventFilterOptions = {}): Promise<AnyEvent[]> {
     const endpoint = `users/${await this.user.getAddress()}/events`
-    const parameterUrl = utils.buildUrl(endpoint, filter)
+    const parameterUrl = utils.buildUrl(endpoint, { query: filter })
     const events = await this.provider.fetchEndpoint<AnyEventRaw[]>(
       parameterUrl
     )

--- a/src/Exchange.ts
+++ b/src/Exchange.ts
@@ -117,14 +117,16 @@ export class Exchange {
    */
   public async getOrders(query: OrdersQuery = {}): Promise<SignedOrder[]> {
     const queryEndpoint = utils.buildUrl(`exchange/orders`, {
-      exchangeContractAddress: query.exchangeContractAddress,
-      feeRecipient: query.feeRecipient,
-      maker: query.maker,
-      makerTokenAddress: query.makerTokenAddress,
-      taker: query.taker,
-      takerTokenAddress: query.takerTokenAddress,
-      tokenAddress: query.tokenAddress,
-      trader: query.trader
+      query: {
+        exchangeContractAddress: query.exchangeContractAddress,
+        feeRecipient: query.feeRecipient,
+        maker: query.maker,
+        makerTokenAddress: query.makerTokenAddress,
+        taker: query.taker,
+        takerTokenAddress: query.takerTokenAddress,
+        tokenAddress: query.tokenAddress,
+        trader: query.trader
+      }
     })
     const orders = await this.provider.fetchEndpoint<SignedOrderRaw[]>(
       queryEndpoint
@@ -168,7 +170,7 @@ export class Exchange {
       })
     ])
     const params = { baseTokenAddress, quoteTokenAddress }
-    const endpoint = utils.buildUrl(`exchange/orderbook`, params)
+    const endpoint = utils.buildUrl(`exchange/orderbook`, { query: params })
     const orderbook = await this.provider.fetchEndpoint<OrderbookRaw>(endpoint)
     const { asks, bids } = orderbook
     return {
@@ -432,7 +434,7 @@ export class Exchange {
     filter: EventFilterOptions = {}
   ): Promise<AnyExchangeEvent[]> {
     const baseUrl = `exchange/${exchangeAddress}/users/${await this.user.getAddress()}/events`
-    const parameterUrl = utils.buildUrl(baseUrl, filter)
+    const parameterUrl = utils.buildUrl(baseUrl, { query: filter })
     const rawEvents = await this.provider.fetchEndpoint<AnyExchangeEventRaw[]>(
       parameterUrl
     )

--- a/src/Interests.ts
+++ b/src/Interests.ts
@@ -41,7 +41,10 @@ export class Interests {
     } = {}
   ): Promise<UserAccruedInterestsObject> {
     const baseUrl = `networks/${networkAddress}/users/${await this.user.getAddress()}/interests`
-    const parameterUrl = utils.buildUrl(baseUrl, options.timeWindowOption || {})
+    const parameterUrl = utils.buildUrl(
+      baseUrl,
+      options.timeWindowOption && { query: options.timeWindowOption }
+    )
 
     const [
       userAccruedInterests,
@@ -72,7 +75,10 @@ export class Interests {
     } = {}
   ): Promise<TrustlineAccruedInterestsObject> {
     const baseUrl = `networks/${networkAddress}/users/${await this.user.getAddress()}/interests/${counterpartyAddress}`
-    const parameterUrl = utils.buildUrl(baseUrl, options.timeWindowOption || {})
+    const parameterUrl = utils.buildUrl(
+      baseUrl,
+      options.timeWindowOption && { query: options.timeWindowOption }
+    )
 
     const [
       trustlineAccruedInterestsRaw,

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -454,7 +454,7 @@ export class Trustline {
     filter: EventFilterOptions = {}
   ): Promise<AnyNetworkTrustlineEvent[]> {
     const endpoint = `networks/${networkAddress}/users/${await this.user.getAddress()}/trustlines/${counterPartyAddress}/events`
-    const parameterUrl = utils.buildUrl(endpoint, filter)
+    const parameterUrl = utils.buildUrl(endpoint, { query: filter })
     const [
       events,
       { networkDecimals, interestRateDecimals }

--- a/src/User.ts
+++ b/src/User.ts
@@ -4,7 +4,7 @@ import { TLProvider } from './providers/TLProvider'
 import { TLSigner } from './signers/TLSigner'
 import { TLWallet } from './wallets/TLWallet'
 
-import utils from './utils'
+import utils, { defaultBaseUrl } from './utils'
 
 import { Amount, Signature, TLWalletData } from './typings'
 
@@ -200,12 +200,19 @@ export class User {
   /**
    * Returns a shareable link which can be send to other users.
    * Contains username and address.
-   * @param username Custom username.
-   * @param customBase Optional custom base for link. Default `trustlines://`.
+   * @param options - any additional options that we should hang on the URL
+   *        options.customBase - convention for a custom base for the URL
+   *        options.name - convention for a name for the user
+   *        options[key] - any other additional options that should be added to the URL
    */
-  public createLink(username: string, customBase?: string): string {
-    const params = ['contact', this.address, username]
-    return utils.createLink(params, customBase)
+  public createLink(options: {
+    [key: string]: string
+    customBase?: string
+    name?: string
+  }): string {
+    const path = ['contact', this.address]
+    const { customBase = defaultBaseUrl, ...rest } = options
+    return utils.buildUrl(customBase, { path, query: rest })
   }
 
   /**

--- a/tests/unit/Contact.test.ts
+++ b/tests/unit/Contact.test.ts
@@ -52,22 +52,39 @@ describe('unit', () => {
       const username = 'testname'
 
       it('should create trustlines:// link', async () => {
-        const contactLink = contact.createLink(FAKE_USER_ADDRESSES[0], username)
+        const contactLink = contact.createLink(FAKE_USER_ADDRESSES[0], {
+          name: username
+        })
         assert.equal(
           contactLink,
-          `trustlines://contact/${FAKE_USER_ADDRESSES[0]}/${username}`
+          `trustlines://contact/${FAKE_USER_ADDRESSES[0]}?name=${username}`
+        )
+      })
+
+      it('should create trustlines:// link with query params', async () => {
+        const contactLink = contact.createLink(FAKE_USER_ADDRESSES[0], {
+          name: username,
+          param1: 'param1',
+          param2: 'param2'
+        })
+        assert.equal(
+          contactLink,
+          `trustlines://contact/${
+            FAKE_USER_ADDRESSES[0]
+          }?name=${username}&param1=param1&param2=param2`
         )
       })
 
       it('should create custom link', async () => {
-        const contactLink = contact.createLink(
-          FAKE_USER_ADDRESSES[0],
-          username,
-          'http://custom.network'
-        )
+        const contactLink = contact.createLink(FAKE_USER_ADDRESSES[0], {
+          name: username,
+          customBase: 'http://custom.network'
+        })
         assert.equal(
           contactLink,
-          `http://custom.network/contact/${FAKE_USER_ADDRESSES[0]}/${username}`
+          `http://custom.network/contact/${
+            FAKE_USER_ADDRESSES[0]
+          }?name=${username}`
         )
       })
     })

--- a/tests/unit/Payment.test.ts
+++ b/tests/unit/Payment.test.ts
@@ -1,0 +1,113 @@
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import 'mocha'
+import { Event } from '../../src/Event'
+import { Payment } from '../../src/Payment'
+import { Transaction } from '../../src/Transaction'
+
+import { User } from '../../src/User'
+import { FakeCurrencyNetwork } from '../helpers/FakeCurrencyNetwork'
+
+import { FakeTLProvider } from '../helpers/FakeTLProvider'
+import { FakeTLSigner } from '../helpers/FakeTLSigner'
+import { FakeTLWallet } from '../helpers/FakeTLWallet'
+
+import { FAKE_NETWORK } from '../Fixtures'
+import { FakeUser } from '../helpers/FakeUser'
+
+chai.use(chaiAsPromised)
+const { assert } = chai
+
+describe('unit', () => {
+  describe('Payment', () => {
+    // Test object
+    let payment: Payment
+    let user: User
+    const init = () => {
+      const provider = new FakeTLProvider()
+      const signer = new FakeTLSigner()
+      const wallet = new FakeTLWallet()
+      const currencyNetwork = new FakeCurrencyNetwork(provider)
+      user = new FakeUser({
+        provider,
+        signer,
+        wallet
+      })
+
+      const event = new Event({
+        currencyNetwork,
+        provider,
+        user
+      })
+
+      const transaction = new Transaction({
+        provider,
+        signer,
+        currencyNetwork
+      })
+
+      payment = new Payment({
+        event,
+        user,
+        transaction,
+        currencyNetwork,
+        provider
+      })
+    }
+
+    describe('#createLink()', () => {
+      beforeEach(() => init())
+
+      it('should create payment request link with network address and no amount', async () => {
+        const paymentRequestLink = await payment.createRequest(
+          FAKE_NETWORK.address
+        )
+
+        const userAddress = await user.getAddress()
+
+        assert.equal(
+          paymentRequestLink,
+          `trustlines://paymentrequest/${FAKE_NETWORK.address}/${userAddress}`
+        )
+      })
+
+      it('should create payment request link with network address and amount', async () => {
+        const paymentRequestLink = await payment.createRequest(
+          FAKE_NETWORK.address,
+          { amount: '100' }
+        )
+
+        const userAddress = await user.getAddress()
+
+        assert.equal(
+          paymentRequestLink,
+          `trustlines://paymentrequest/${
+            FAKE_NETWORK.address
+          }/${userAddress}/100`
+        )
+      })
+
+      it('should create payment request link with network address, amount and query params', async () => {
+        const paymentRequestLink = await payment.createRequest(
+          FAKE_NETWORK.address,
+
+          {
+            amount: '100',
+            subject: 'subject',
+            note: 'my note',
+            username: 'username'
+          }
+        )
+
+        const userAddress = await user.getAddress()
+
+        assert.equal(
+          paymentRequestLink,
+          `trustlines://paymentrequest/${
+            FAKE_NETWORK.address
+          }/${userAddress}/100?subject=subject&note=my%20note&username=username`
+        )
+      })
+    })
+  })
+})

--- a/tests/unit/User.test.ts
+++ b/tests/unit/User.test.ts
@@ -192,21 +192,38 @@ describe('unit', () => {
     describe('#createLink()', () => {
       beforeEach(() => init())
 
-      const username = 'testname'
+      const name = 'testname'
 
       it('should create trustlines:// link', async () => {
-        const contactLink = user.createLink(username)
+        const contactLink = user.createLink({ name })
         assert.equal(
           contactLink,
-          `trustlines://contact/${user.address}/${username}`
+          `trustlines://contact/${user.address}?name=${name}`
+        )
+      })
+
+      it('should create trustlines:// link with queryParams', async () => {
+        const contactLink = user.createLink({
+          name,
+          param1: 'param1',
+          param2: 'param2'
+        })
+        assert.equal(
+          contactLink,
+          `trustlines://contact/${
+            user.address
+          }?name=${name}&param1=param1&param2=param2`
         )
       })
 
       it('should create custom link', async () => {
-        const contactLink = user.createLink(username, 'http://custom.network')
+        const contactLink = user.createLink({
+          name,
+          customBase: 'http://custom.network'
+        })
         assert.equal(
           contactLink,
-          `http://custom.network/contact/${user.address}/${username}`
+          `http://custom.network/contact/${user.address}?name=${name}`
         )
       })
     })

--- a/tests/unit/Utils.test.ts
+++ b/tests/unit/Utils.test.ts
@@ -68,83 +68,63 @@ describe('unit', () => {
 
       it('should return query url with encoded params for base http://test.com/api', () => {
         const base = 'http://test.com/api'
-        const params = {
+        const query = {
           key1: 'value1',
           key2: ' ',
           key3: '?'
         }
         const queryUrl = 'http://test.com/api?key1=value1&key2=%20&key3=%3F'
-        assert.equal(utils.buildUrl(base, params), queryUrl)
+        assert.equal(utils.buildUrl(base, { query }), queryUrl)
       })
 
       it('should return query url with encoded params for base http://test.com/api/', () => {
         const base = 'http://test.com/api/'
-        const params = {
+        const query = {
           key1: 'value1',
           key2: ' ',
           key3: '?'
         }
         const queryUrl = 'http://test.com/api?key1=value1&key2=%20&key3=%3F'
-        assert.equal(utils.buildUrl(base, params), queryUrl)
+        assert.equal(utils.buildUrl(base, { query }), queryUrl)
       })
 
       it('should return query url with encoded params for base trustlines://', () => {
         const base = 'trustlines://action'
-        const params = {
+        const query = {
           key1: 'value1',
           key2: ' ',
           key3: '?'
         }
         const queryUrl = 'trustlines://action?key1=value1&key2=%20&key3=%3F'
-        assert.equal(utils.buildUrl(base, params), queryUrl)
+        assert.equal(utils.buildUrl(base, { query }), queryUrl)
       })
 
       it('should return url with encoded path for http://trustlines', () => {
         const base = 'http://trustlines'
-        const params = ['contact', '0x00', 'username with spaces']
+        const path = ['contact', '0x00', 'username with spaces']
         const url = 'http://trustlines/contact/0x00/username%20with%20spaces'
-        assert.equal(utils.buildUrl(base, params), url)
+        assert.equal(utils.buildUrl(base, { path }), url)
       })
 
       it('should return url with encoded path http://test.com/api', () => {
         const base = 'http://test.com/api'
-        const params = ['contact', '0x00', 'username with spaces']
+        const path = ['contact', '0x00', 'username with spaces']
         const url = 'http://test.com/api/contact/0x00/username%20with%20spaces'
-        assert.equal(utils.buildUrl(base, params), url)
+        assert.equal(utils.buildUrl(base, { path }), url)
       })
 
       it('should return url with encoded path http://test.com/api/', () => {
         const base = 'http://test.com/api/'
-        const params = ['contact', '0x00', 'username with spaces']
+        const path = ['contact', '0x00', 'username with spaces']
         const url = 'http://test.com/api/contact/0x00/username%20with%20spaces'
-        assert.equal(utils.buildUrl(base, params), url)
+        assert.equal(utils.buildUrl(base, { path }), url)
       })
 
       it('should return url with encoded path trustlines://', () => {
         const base = 'trustlines://'
-        const params = ['contact', '0x00', 'username with spaces']
+        const path = ['contact', '0x00', 'username with spaces']
         const url = 'trustlines://contact/0x00/username%20with%20spaces'
-        assert.equal(utils.buildUrl(base, params), url)
-      })
-    })
-
-    describe('#createLink()', () => {
-      it('should return url in trustlines link schema', () => {
-        const params = ['contact', '0x']
-        const url = 'trustlines://contact/0x'
-        assert.equal(utils.createLink(params), url)
-      })
-
-      it('should return url in custom link schema for http://custom.com/api', () => {
-        const params = ['contact', '0x']
-        const url = 'http://custom.com/api/contact/0x'
-        assert.equal(utils.createLink(params, 'http://custom.com/api'), url)
-      })
-
-      it('should return url in custom link schema for http://custom.com/api/', () => {
-        const params = ['contact', '0x']
-        const url = 'http://custom.com/api/contact/0x'
-        assert.equal(utils.createLink(params, 'http://custom.com/api/'), url)
+        assert.equal(utils.buildUrl(base, { path }), url)
       })
     })
 


### PR DESCRIPTION
The buildURL function was expecting either an array or an object for pathParams. Depending on what it receives it generates a path URL or a query URL. That was not optimal in some situations.

I’ve changed the signature of the function to expect pathParams - array and queryParams - object. This way we can generate a url with both a path and query.

This is helpful in situations where users of the library would like to generate links to user account, contact or payment request but they also need to have some additional query params.

In the past the payment createRequest function was generating different paths depending on whether one provides a subject (it was difficult to match such paths and created a lot of overhead). Now the path is always the same:
/network/:network_address/:user_address/:amount if the user needs additional params to that url they are added as query params ?subject=1&note=note etc

fixes #336