### PR TITLE
Remove transactionId for transactionHash

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -109,7 +109,7 @@ export interface BlockchainEvent {
   timestamp: number
   blockNumber: number
   status: string
-  transactionId: string
+  transactionHash: string
   blockHash: string
   logIndex: number
 }

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -305,7 +305,7 @@ export const FAKE_TRANSFER_EVENT = {
   status: 'pending',
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'Transfer',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
@@ -325,7 +325,7 @@ export const FAKE_FORMATTED_TRANSFER_EVENT = {
   status: 'pending',
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'Transfer',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
@@ -345,7 +345,7 @@ export const FAKE_TRUSTLINE_UPDATE_REQUEST_EVENT = {
   status: 'pending',
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'TrustlineUpdateRequest',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
@@ -364,7 +364,7 @@ export const FAKE_TRUSTLINE_UPDATE_EVENT = {
   status: 'pending',
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'TrustlineUpdate',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
@@ -379,7 +379,7 @@ export const FAKE_TRUSTLINE_CANCEL_EVENT = {
   status: 'pending',
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'TrustlineUpdateCancel',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
@@ -395,7 +395,7 @@ export const FAKE_TOKEN_EVENT = {
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
   tokenAddress: '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'Transfer',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
@@ -414,7 +414,7 @@ export const FAKE_FILL_EVENT = {
   takerTokenAddress: '0xcE2D6f8bc55A61428D32947bC9Bc7F2DE1640B18',
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'LogFill',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
@@ -433,7 +433,7 @@ export const FAKE_CANCEL_EVENT = {
   takerTokenAddress: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
   timestamp: 123456789,
   to: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA',
-  transactionId:
+  transactionHash:
     '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
   type: 'LogCancel',
   user: '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'

--- a/tests/e2e/EthWrapper.test.ts
+++ b/tests/e2e/EthWrapper.test.ts
@@ -260,7 +260,7 @@ describe('e2e', () => {
           expect(latestLog.tokenAddress).to.equal(ethWrapperAddress)
           expect(latestLog.status).to.be.a('string')
           expect(latestLog.timestamp).to.be.a('number')
-          expect(latestLog.transactionId).to.be.a('string')
+          expect(latestLog.transactionHash).to.be.a('string')
           expect(latestLog.type).to.equal('Deposit')
         })
 
@@ -275,7 +275,7 @@ describe('e2e', () => {
           expect(latestLog.tokenAddress).to.equal(ethWrapperAddress)
           expect(latestLog.status).to.be.a('string')
           expect(latestLog.timestamp).to.be.a('number')
-          expect(latestLog.transactionId).to.be.a('string')
+          expect(latestLog.transactionHash).to.be.a('string')
           expect(latestLog.type).to.equal('Withdrawal')
         })
 
@@ -292,7 +292,7 @@ describe('e2e', () => {
           expect(latestLog.to).to.equal(tl2.user.address)
           expect(latestLog.counterParty).to.equal(tl2.user.address)
           expect(latestLog.user).to.equal(tl1.user.address)
-          expect(latestLog.transactionId).to.be.a('string')
+          expect(latestLog.transactionHash).to.be.a('string')
           expect(latestLog.type).to.equal('Transfer')
         })
       })

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -100,15 +100,15 @@ describe('e2e', () => {
     })
 
     describe('#getAll()', async () => {
-      let updateTxId
-      let acceptTxId
-      let cancelUpdateTxId
-      let tlTransferTxId
-      let depositTxId
-      let withdrawTxId
-      let transferTxId
-      let fillTxId
-      let cancelTxId
+      let updateTxHash
+      let acceptTxHash
+      let cancelUpdateTxHash
+      let tlTransferTxHash
+      let depositTxHash
+      let withdrawTxHash
+      let transferTxHash
+      let fillTxHash
+      let cancelTxHash
       let order
 
       before(async () => {
@@ -127,13 +127,13 @@ describe('e2e', () => {
           1000,
           500
         )
-        updateTxId = await tl1.trustline.confirm(updateTx.rawTx)
+        updateTxHash = await tl1.trustline.confirm(updateTx.rawTx)
         await wait()
         const cancelUpdateTx = await tl1.trustline.prepareCancelTrustlineUpdate(
           network2.address,
           user2.address
         )
-        cancelUpdateTxId = await tl1.trustline.confirm(cancelUpdateTx.rawTx)
+        cancelUpdateTxHash = await tl1.trustline.confirm(cancelUpdateTx.rawTx)
         await wait()
         const secondUpdateTx = await tl1.trustline.prepareUpdate(
           network2.address,
@@ -149,7 +149,7 @@ describe('e2e', () => {
           500,
           1000
         )
-        acceptTxId = await tl2.trustline.confirm(acceptTx.rawTx)
+        acceptTxHash = await tl2.trustline.confirm(acceptTx.rawTx)
         await wait()
         const tlTransferTx = await tl1.payment.prepare(
           network2.address,
@@ -157,7 +157,7 @@ describe('e2e', () => {
           1,
           { extraData }
         )
-        tlTransferTxId = await tl1.payment.confirm(tlTransferTx.rawTx)
+        tlTransferTxHash = await tl1.payment.confirm(tlTransferTx.rawTx)
         await wait()
 
         // Token events
@@ -165,20 +165,20 @@ describe('e2e', () => {
           ethWrapperAddress,
           0.005
         )
-        depositTxId = await tl1.ethWrapper.confirm(depositTx.rawTx)
+        depositTxHash = await tl1.ethWrapper.confirm(depositTx.rawTx)
         await wait()
         const withdrawTx = await tl1.ethWrapper.prepWithdraw(
           ethWrapperAddress,
           0.001
         )
-        withdrawTxId = await tl1.ethWrapper.confirm(withdrawTx.rawTx)
+        withdrawTxHash = await tl1.ethWrapper.confirm(withdrawTx.rawTx)
         await wait()
         const transferTx = await tl1.ethWrapper.prepTransfer(
           ethWrapperAddress,
           tl2.user.address,
           0.002
         )
-        transferTxId = await tl1.ethWrapper.confirm(transferTx.rawTx)
+        transferTxHash = await tl1.ethWrapper.confirm(transferTx.rawTx)
         await wait()
 
         // Exchange events
@@ -194,12 +194,12 @@ describe('e2e', () => {
           tl1.exchange.prepCancelOrder(order, 1)
         ])
 
-        const exTxIds = await Promise.all([
+        const exTxHashs = await Promise.all([
           tl2.exchange.confirm(fillTx.rawTx),
           tl1.exchange.confirm(cancelTx.rawTx)
         ])
-        fillTxId = exTxIds[0]
-        cancelTxId = exTxIds[1]
+        fillTxHash = exTxHashs[0]
+        cancelTxHash = exTxHashs[1]
         await wait()
       })
 
@@ -208,7 +208,7 @@ describe('e2e', () => {
 
         // events thrown on trustline update request
         const updateRequestEvents = allEvents.filter(
-          ({ transactionId }) => transactionId === updateTxId
+          ({ transactionHash }) => transactionHash === updateTxHash
         )
         // check event TrustlineUpdateRequest
         expect(
@@ -219,7 +219,7 @@ describe('e2e', () => {
         expect(updateRequestEvents[0].timestamp).to.be.a('number')
         expect(updateRequestEvents[0].blockNumber).to.be.a('number')
         expect(updateRequestEvents[0].status).to.be.a('string')
-        expect(updateRequestEvents[0].transactionId).to.equal(updateTxId)
+        expect(updateRequestEvents[0].transactionHash).to.equal(updateTxHash)
         expect(updateRequestEvents[0].blockHash).to.be.a('string')
         expect(updateRequestEvents[0].logIndex).to.be.a('number')
         expect(updateRequestEvents[0].direction).to.equal('sent')
@@ -242,7 +242,7 @@ describe('e2e', () => {
 
         // events thrown on trustline update cancel
         const cancelUpdateEvents = allEvents.filter(
-          ({ transactionId }) => transactionId === cancelUpdateTxId
+          ({ transactionHash }) => transactionHash === cancelUpdateTxHash
         )
         // check event TrustlineUpdateCancel
         expect(
@@ -253,7 +253,9 @@ describe('e2e', () => {
         expect(cancelUpdateEvents[0].timestamp).to.be.a('number')
         expect(cancelUpdateEvents[0].blockNumber).to.be.a('number')
         expect(cancelUpdateEvents[0].status).to.be.a('string')
-        expect(cancelUpdateEvents[0].transactionId).to.equal(cancelUpdateTxId)
+        expect(cancelUpdateEvents[0].transactionHash).to.equal(
+          cancelUpdateTxHash
+        )
         expect(cancelUpdateEvents[0].blockHash).to.be.a('string')
         expect(cancelUpdateEvents[0].logIndex).to.be.a('number')
         expect(cancelUpdateEvents[0].direction).to.equal('sent')
@@ -267,7 +269,7 @@ describe('e2e', () => {
 
         // events thrown on trustline update
         const updateEvents = allEvents.filter(
-          ({ transactionId }) => transactionId === acceptTxId
+          ({ transactionHash }) => transactionHash === acceptTxHash
         )
         // check event TrustlineUpdate
         expect(updateEvents, 'Trustline Update should exist').to.have.length(1)
@@ -275,7 +277,7 @@ describe('e2e', () => {
         expect(updateEvents[0].timestamp).to.be.a('number')
         expect(updateEvents[0].blockNumber).to.be.a('number')
         expect(updateEvents[0].status).to.be.a('string')
-        expect(updateEvents[0].transactionId).to.equal(acceptTxId)
+        expect(updateEvents[0].transactionHash).to.equal(acceptTxHash)
         expect(updateEvents[0].blockHash).to.be.a('string')
         expect(updateEvents[0].logIndex).to.be.a('number')
         expect(updateEvents[0].direction).to.equal('sent')
@@ -298,7 +300,7 @@ describe('e2e', () => {
 
         // events thrown on trustlines transfer
         const tlTransferEvents = allEvents.filter(
-          ({ transactionId }) => transactionId === tlTransferTxId
+          ({ transactionHash }) => transactionHash === tlTransferTxHash
         )
         // check event Trustlines Transfer
         expect(
@@ -309,7 +311,7 @@ describe('e2e', () => {
         expect(tlTransferEvents[0].timestamp).to.be.a('number')
         expect(tlTransferEvents[0].blockNumber).to.be.a('number')
         expect(tlTransferEvents[0].status).to.be.a('string')
-        expect(tlTransferEvents[0].transactionId).to.equal(tlTransferTxId)
+        expect(tlTransferEvents[0].transactionHash).to.equal(tlTransferTxHash)
         expect(tlTransferEvents[0].blockHash).to.be.a('string')
         expect(tlTransferEvents[0].logIndex).to.be.a('number')
         expect(tlTransferEvents[0].from).to.equal(tl1.user.address)
@@ -329,7 +331,7 @@ describe('e2e', () => {
 
         // events thrown on deposit
         const depositEvents = allEvents.filter(
-          ({ transactionId }) => transactionId === depositTxId
+          ({ transactionHash }) => transactionHash === depositTxHash
         )
         // check event Deposit
         expect(depositEvents, 'Deposit should exist').to.have.length(1)
@@ -337,7 +339,7 @@ describe('e2e', () => {
         expect(depositEvents[0].timestamp).to.be.a('number')
         expect(depositEvents[0].blockNumber).to.be.a('number')
         expect(depositEvents[0].status).to.be.a('string')
-        expect(depositEvents[0].transactionId).to.equal(depositTxId)
+        expect(depositEvents[0].transactionHash).to.equal(depositTxHash)
         expect(depositEvents[0].blockHash).to.be.a('string')
         expect(depositEvents[0].logIndex).to.be.a('number')
         expect(depositEvents[0].from).to.equal(tl1.user.address)
@@ -355,7 +357,7 @@ describe('e2e', () => {
 
         // events thrown on withdraw
         const withdrawEvents = allEvents.filter(
-          ({ transactionId }) => transactionId === withdrawTxId
+          ({ transactionHash }) => transactionHash === withdrawTxHash
         )
         // check event Withdraw
         expect(withdrawEvents, 'Withdraw should exist').to.have.length(1)
@@ -363,7 +365,7 @@ describe('e2e', () => {
         expect(withdrawEvents[0].timestamp).to.be.a('number')
         expect(withdrawEvents[0].blockNumber).to.be.a('number')
         expect(withdrawEvents[0].status).to.be.a('string')
-        expect(withdrawEvents[0].transactionId).to.equal(withdrawTxId)
+        expect(withdrawEvents[0].transactionHash).to.equal(withdrawTxHash)
         expect(withdrawEvents[0].blockHash).to.be.a('string')
         expect(withdrawEvents[0].logIndex).to.be.a('number')
         expect(withdrawEvents[0].from).to.equal(tl1.user.address)
@@ -381,8 +383,8 @@ describe('e2e', () => {
 
         // events thrown on wrapped eth transfer
         const wethTransferEvents = allEvents.filter(
-          ({ transactionId, type }) =>
-            transactionId === transferTxId && type === 'Transfer'
+          ({ transactionHash, type }) =>
+            transactionHash === transferTxHash && type === 'Transfer'
         )
         // check event Wrapped ETH Transfer
         expect(wethTransferEvents, 'ETH Transfer should exist').to.have.length(
@@ -392,7 +394,7 @@ describe('e2e', () => {
         expect(wethTransferEvents[0].timestamp).to.be.a('number')
         expect(wethTransferEvents[0].blockNumber).to.be.a('number')
         expect(wethTransferEvents[0].status).to.be.a('string')
-        expect(wethTransferEvents[0].transactionId).to.equal(transferTxId)
+        expect(wethTransferEvents[0].transactionHash).to.equal(transferTxHash)
         expect(wethTransferEvents[0].blockHash).to.be.a('string')
         expect(wethTransferEvents[0].logIndex).to.be.a('number')
         expect(wethTransferEvents[0].from).to.equal(tl1.user.address)
@@ -411,8 +413,8 @@ describe('e2e', () => {
 
         // events thrown on fill order
         const fillEvents = allEvents.filter(
-          ({ transactionId, type }) =>
-            transactionId === fillTxId && type === 'LogFill'
+          ({ transactionHash, type }) =>
+            transactionHash === fillTxHash && type === 'LogFill'
         )
         // check event LogFill
         expect(fillEvents, 'Log Fill should exist').to.have.length(1)
@@ -420,7 +422,7 @@ describe('e2e', () => {
         expect(fillEvents[0].timestamp).to.be.a('number')
         expect(fillEvents[0].blockNumber).to.be.a('number')
         expect(fillEvents[0].status).to.be.a('string')
-        expect(fillEvents[0].transactionId).to.equal(fillTxId)
+        expect(fillEvents[0].transactionHash).to.equal(fillTxHash)
         expect(fillEvents[0].blockHash).to.be.a('string')
         expect(fillEvents[0].logIndex).to.be.a('number')
         expect(fillEvents[0].from).to.equal(tl1.user.address)
@@ -446,8 +448,8 @@ describe('e2e', () => {
 
         // events thrown on cancel order
         const cancelEvents = allEvents.filter(
-          ({ transactionId, type }) =>
-            transactionId === cancelTxId && type === 'LogCancel'
+          ({ transactionHash, type }) =>
+            transactionHash === cancelTxHash && type === 'LogCancel'
         )
         // check event LogCancel
         expect(cancelEvents, 'Log Cancel should exist').to.have.length(1)
@@ -455,7 +457,7 @@ describe('e2e', () => {
         expect(cancelEvents[0].timestamp).to.be.a('number')
         expect(cancelEvents[0].blockNumber).to.be.a('number')
         expect(cancelEvents[0].status).to.be.a('string')
-        expect(cancelEvents[0].transactionId).to.equal(cancelTxId)
+        expect(cancelEvents[0].transactionHash).to.equal(cancelTxHash)
         expect(cancelEvents[0].blockHash).to.be.a('string')
         expect(cancelEvents[0].logIndex).to.be.a('number')
         expect(cancelEvents[0].from).to.equal(tl1.user.address)

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -277,9 +277,9 @@ describe('e2e', () => {
             1,
             { extraData }
           )
-          const txId = await tl1.payment.confirm(rawTx)
+          const txHash = await tl1.payment.confirm(rawTx)
           await wait()
-          expect(txId).to.be.a('string')
+          expect(txHash).to.be.a('string')
           expect(
             (await tl1.trustline.get(network.address, user2.address)).balance
               .value
@@ -294,9 +294,9 @@ describe('e2e', () => {
             1,
             options
           )
-          const txId = await tl1.payment.confirm(rawTx)
+          const txHash = await tl1.payment.confirm(rawTx)
           await wait()
-          expect(txId).to.be.a('string')
+          expect(txHash).to.be.a('string')
         })
       })
 
@@ -331,7 +331,7 @@ describe('e2e', () => {
           expect(latestTransfer.networkAddress).to.be.a('string')
           expect(latestTransfer.status).to.be.a('string')
           expect(latestTransfer.timestamp).to.be.a('number')
-          expect(latestTransfer.transactionId).to.be.a('string')
+          expect(latestTransfer.transactionHash).to.be.a('string')
           expect(latestTransfer.type).to.equal('Transfer')
         })
       })

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -129,7 +129,7 @@ describe('e2e', () => {
           await wait()
         })
 
-        it('should return txId for network WITHOUT interest rates', async () => {
+        it('should return txHash for network WITHOUT interest rates', async () => {
           const txWithoutInterestRates = await tl1.trustline.prepareUpdate(
             networkWithoutInterestRates.address,
             user2.address,
@@ -141,7 +141,7 @@ describe('e2e', () => {
           ).to.eventually.be.a('string')
         })
 
-        it('should return txId for network with DEFAULT interest rates', async () => {
+        it('should return txHash for network with DEFAULT interest rates', async () => {
           const txDefaultInterestRates = await tl1.trustline.prepareUpdate(
             networkWithoutInterestRates.address,
             user2.address,
@@ -153,7 +153,7 @@ describe('e2e', () => {
           ).to.eventually.be.a('string')
         })
 
-        it('should return txId for network with CUSTOM interest rates', async () => {
+        it('should return txHash for network with CUSTOM interest rates', async () => {
           const txCustomInterestRates = await tl1.trustline.prepareUpdate(
             networkWithoutInterestRates.address,
             user2.address,
@@ -170,7 +170,7 @@ describe('e2e', () => {
           ).to.eventually.be.a('string')
         })
 
-        it('should return txId for trustline update request with freezing', async () => {
+        it('should return txHash for trustline update request with freezing', async () => {
           const txFreezing = await tl1.trustline.prepareUpdate(
             networkCustomInterestRates.address,
             user2.address,
@@ -213,7 +213,7 @@ describe('e2e', () => {
           await wait()
         })
 
-        it('should return txId for trustline update cancel tx', async () => {
+        it('should return txHash for trustline update cancel tx', async () => {
           const { rawTx } = await tl1.trustline.prepareUpdate(
             networkWithoutInterestRates.address,
             user2.address,
@@ -246,7 +246,7 @@ describe('e2e', () => {
             given,
             received
           )
-          const txId = await tl1.trustline.confirm(rawTx)
+          const txHash = await tl1.trustline.confirm(rawTx)
 
           // make sure tx is mined
           await wait()
@@ -257,7 +257,7 @@ describe('e2e', () => {
           const latestRequest = requests[requests.length - 1]
           expect(latestRequest.direction).to.equal('sent')
           expect(latestRequest.from).to.equal(user1.address)
-          expect(latestRequest.transactionId).to.equal(txId)
+          expect(latestRequest.transactionHash).to.equal(txHash)
           expect(latestRequest.to).to.equal(user2.address)
           expect(latestRequest.blockNumber).to.be.a('number')
           expect(latestRequest.timestamp).to.be.a('number')
@@ -298,7 +298,7 @@ describe('e2e', () => {
             given,
             received
           )
-          const txId = await tl1.trustline.confirm(rawTx)
+          const txHash = await tl1.trustline.confirm(rawTx)
 
           // make sure tx is mined
           await wait()
@@ -309,7 +309,7 @@ describe('e2e', () => {
           const latestRequest = requests[requests.length - 1]
           expect(latestRequest.direction).to.equal('sent')
           expect(latestRequest.from).to.equal(user1.address)
-          expect(latestRequest.transactionId).to.equal(txId)
+          expect(latestRequest.transactionHash).to.equal(txHash)
           expect(latestRequest.to).to.equal(user2.address)
           expect(latestRequest.blockNumber).to.be.a('number')
           expect(latestRequest.timestamp).to.be.a('number')
@@ -359,7 +359,7 @@ describe('e2e', () => {
               isFrozen
             }
           )
-          const txId = await tl1.trustline.confirm(rawTx)
+          const txHash = await tl1.trustline.confirm(rawTx)
 
           // make sure tx is mined
           await wait()
@@ -370,7 +370,7 @@ describe('e2e', () => {
           const latestRequest = requests[requests.length - 1]
           expect(latestRequest.direction).to.equal('sent')
           expect(latestRequest.from).to.equal(user1.address)
-          expect(latestRequest.transactionId).to.equal(txId)
+          expect(latestRequest.transactionHash).to.equal(txHash)
           expect(latestRequest.to).to.equal(user2.address)
           expect(latestRequest.blockNumber).to.be.a('number')
           expect(latestRequest.timestamp).to.be.a('number')
@@ -416,7 +416,7 @@ describe('e2e', () => {
             received,
             { interestRateGiven, interestRateReceived, isFrozen: true }
           )
-          const txId = await tl1.trustline.confirm(rawTx)
+          const txHash = await tl1.trustline.confirm(rawTx)
 
           // make sure tx is mined
           await wait()
@@ -427,7 +427,7 @@ describe('e2e', () => {
           const latestRequest = requests[requests.length - 1]
           expect(latestRequest.direction).to.equal('sent')
           expect(latestRequest.from).to.equal(user1.address)
-          expect(latestRequest.transactionId).to.equal(txId)
+          expect(latestRequest.transactionHash).to.equal(txHash)
           expect(latestRequest.to).to.equal(user2.address)
           expect(latestRequest.blockNumber).to.be.a('number')
           expect(latestRequest.timestamp).to.be.a('number')
@@ -479,7 +479,7 @@ describe('e2e', () => {
             networkWithoutInterestRates.address,
             user2.address
           )
-          const txId = await tl1.trustline.confirm(cancelUpdateTx.rawTx)
+          const txHash = await tl1.trustline.confirm(cancelUpdateTx.rawTx)
 
           // make sure tx is mined
           await wait()
@@ -490,7 +490,7 @@ describe('e2e', () => {
           const latestRequest = requests[requests.length - 1]
           expect(latestRequest.direction).to.equal('sent')
           expect(latestRequest.from).to.equal(user1.address)
-          expect(latestRequest.transactionId).to.equal(txId)
+          expect(latestRequest.transactionHash).to.equal(txHash)
           expect(latestRequest.to).to.equal(user2.address)
           expect(latestRequest.blockNumber).to.be.a('number')
           expect(latestRequest.timestamp).to.be.a('number')
@@ -525,7 +525,7 @@ describe('e2e', () => {
             user2.address,
             1
           )
-          const txId = await tl1.trustline.confirm(transferTx.rawTx)
+          const txHash = await tl1.trustline.confirm(transferTx.rawTx)
 
           // make sure tx is mined
           await wait()
@@ -543,7 +543,7 @@ describe('e2e', () => {
             balanceUpdateEvents[balanceUpdateEvents.length - 1]
           expect(latestBalanceUpdate.direction).to.equal('sent')
           expect(latestBalanceUpdate.from).to.equal(user1.address)
-          expect(latestBalanceUpdate.transactionId).to.equal(txId)
+          expect(latestBalanceUpdate.transactionHash).to.equal(txHash)
           expect(latestBalanceUpdate.to).to.equal(user2.address)
           expect(latestBalanceUpdate.blockNumber).to.be.a('number')
           expect(latestBalanceUpdate.timestamp).to.be.a('number')
@@ -629,9 +629,9 @@ describe('e2e', () => {
         const interestRateReceived = 0.02
         const isFrozen = false
 
-        let acceptTxIdWithoutInterestRates
-        let acceptTxIdDefaultInterestRates
-        let acceptTxIdCustomInterestRates
+        let acceptTxHashWithoutInterestRates
+        let acceptTxHashDefaultInterestRates
+        let acceptTxHashCustomInterestRates
 
         before(async () => {
           const updateTxWithoutInterestRates = await tl1.trustline.prepareUpdate(
@@ -675,7 +675,7 @@ describe('e2e', () => {
             received,
             given
           )
-          acceptTxIdWithoutInterestRates = await tl2.trustline.confirm(
+          acceptTxHashWithoutInterestRates = await tl2.trustline.confirm(
             acceptTxWithoutInterestRates.rawTx
           )
 
@@ -687,7 +687,7 @@ describe('e2e', () => {
             received,
             given
           )
-          acceptTxIdDefaultInterestRates = await tl2.trustline.confirm(
+          acceptTxHashDefaultInterestRates = await tl2.trustline.confirm(
             acceptTxDefaultInterestRates.rawTx
           )
 
@@ -704,7 +704,7 @@ describe('e2e', () => {
               isFrozen
             }
           )
-          acceptTxIdCustomInterestRates = await tl2.trustline.confirm(
+          acceptTxHashCustomInterestRates = await tl2.trustline.confirm(
             acceptTxCustomInterestRates.rawTx
           )
 
@@ -727,8 +727,8 @@ describe('e2e', () => {
             networkWithoutInterestRates.address
           )
           expect(latestUpdate.status).to.be.a('string')
-          expect(latestUpdate.transactionId).to.equal(
-            acceptTxIdWithoutInterestRates
+          expect(latestUpdate.transactionHash).to.equal(
+            acceptTxHashWithoutInterestRates
           )
           expect(latestUpdate.type).to.equal('TrustlineUpdate')
           expect(latestUpdate.received).to.have.keys('raw', 'value', 'decimals')
@@ -766,8 +766,8 @@ describe('e2e', () => {
             networkDefaultInterestRates.address
           )
           expect(latestUpdate.status).to.be.a('string')
-          expect(latestUpdate.transactionId).to.equal(
-            acceptTxIdDefaultInterestRates
+          expect(latestUpdate.transactionHash).to.equal(
+            acceptTxHashDefaultInterestRates
           )
           expect(latestUpdate.type).to.equal('TrustlineUpdate')
           expect(latestUpdate.received).to.have.keys('raw', 'value', 'decimals')
@@ -809,8 +809,8 @@ describe('e2e', () => {
             networkCustomInterestRates.address
           )
           expect(latestUpdate.status).to.be.a('string')
-          expect(latestUpdate.transactionId).to.equal(
-            acceptTxIdCustomInterestRates
+          expect(latestUpdate.transactionHash).to.equal(
+            acceptTxHashCustomInterestRates
           )
           expect(latestUpdate.type).to.equal('TrustlineUpdate')
           expect(latestUpdate.received).to.have.keys('raw', 'value', 'decimals')
@@ -844,7 +844,7 @@ describe('e2e', () => {
         const interestRateReceived = 0.02
         const isFrozen = true
 
-        let acceptTxId
+        let acceptTxHash
 
         before(async () => {
           const updateTx = await tl1.trustline.prepareUpdate(
@@ -869,7 +869,7 @@ describe('e2e', () => {
               isFrozen
             }
           )
-          acceptTxId = await tl2.trustline.confirm(acceptTx.rawTx)
+          acceptTxHash = await tl2.trustline.confirm(acceptTx.rawTx)
 
           await wait()
         })
@@ -921,7 +921,7 @@ describe('e2e', () => {
             networkCustomInterestRates.address
           )
           expect(latestUpdate.status).to.be.a('string')
-          expect(latestUpdate.transactionId).to.equal(acceptTxId)
+          expect(latestUpdate.transactionHash).to.equal(acceptTxHash)
           expect(latestUpdate.type).to.equal('TrustlineUpdate')
           expect(latestUpdate.received).to.have.keys('raw', 'value', 'decimals')
           expect(latestUpdate.received.value).to.eq(received.toString())
@@ -953,7 +953,7 @@ describe('e2e', () => {
             networkWithoutInterestRates.address,
             user2.address
           )
-          expect(trustline).to.have.keys([
+          expect(trustline).to.include.all.keys([
             'counterParty',
             'currencyNetwork',
             'user',

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -154,8 +154,8 @@ describe('unit', () => {
           100,
           200
         )
-        const txId = await trustline.confirm(rawTx)
-        assert.isString(txId)
+        const txHash = await trustline.confirm(rawTx)
+        assert.isString(txHash)
       })
     })
 


### PR DESCRIPTION
We remove the `transactionId` and replace it by `transactionHash`.
The transactionId is not truely removed yet, for backwards
compatibility.

To in future not always have failing e2e tests when we add a field to
events, I replaced `have.keys` with `include.all.keys`, which only checks
that the keys are a superset of the necessary keys.