### PR TITLE
Feature/add reference id for payments

### DIFF
--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -95,12 +95,17 @@ export class Payment {
     networkAddress: string,
     receiverAddress: string,
     value: number | string,
-    options: PaymentOptions = {}
+    options: PaymentOptions = {},
+    referenceId: string = ''
   ): Promise<PaymentTxObject> {
     const { gasPrice, gasLimit, networkDecimals, extraData } = options
     const decimals = await this.currencyNetwork.getDecimals(networkAddress, {
       networkDecimals
     })
+    const extraDataWithReferenceId = this.extendExtraDataByReferenceId(
+      extraData,
+      referenceId
+    )
     const { path, maxFees, feePayer } = await this.getTransferPathInfo(
       networkAddress,
       await this.user.getAddress(),
@@ -127,7 +132,7 @@ export class Payment {
           ),
           utils.convertToHexString(new BigNumber(maxFees.raw)),
           path,
-          extraData || '0x'
+          extraDataWithReferenceId
         ],
         {
           gasLimit: gasLimit
@@ -436,6 +441,22 @@ export class Payment {
       feesPaid: transferInformation.feesPaid.map(feesPaidRaw =>
         utils.formatToAmount(feesPaidRaw, networkDecimals)
       )
+    }
+  }
+
+  private extendExtraDataByReferenceId(
+    extraData: string,
+    referenceId: string = ''
+  ): string {
+    // TODO:
+    // Implement some useful encoding. This here simply makes sure that the
+    // String concatenations works.
+    if (!extraData && !referenceId) {
+      return '0x'
+    } else if (!extraData) {
+      return referenceId
+    } else {
+      return extraData + referenceId
     }
   }
 }

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -90,21 +90,27 @@ export class Payment {
    * @param options.gasLimit Custom gas limit.
    * @param options.feePayer Either `sender` or `receiver`. Specifies who pays network fees.
    * @param options.extraData Extra data that will appear in the Transfer event when successful.
+   * @param options.paymentRequestId Payment request identifier that gets encoded to the extra data.
    */
   public async prepare(
     networkAddress: string,
     receiverAddress: string,
     value: number | string,
-    options: PaymentOptions = {},
-    referenceId: string = ''
+    options: PaymentOptions = {}
   ): Promise<PaymentTxObject> {
-    const { gasPrice, gasLimit, networkDecimals, extraData } = options
+    const {
+      gasPrice,
+      gasLimit,
+      networkDecimals,
+      extraData,
+      paymentRequestId
+    } = options
     const decimals = await this.currencyNetwork.getDecimals(networkAddress, {
       networkDecimals
     })
-    const extraDataWithReferenceId = this.extendExtraDataByReferenceId(
+    const extraDataWithPaymentRequestId = this.extendExtraDataByPaymentRequestId(
       extraData,
-      referenceId
+      paymentRequestId
     )
     const { path, maxFees, feePayer } = await this.getTransferPathInfo(
       networkAddress,
@@ -113,6 +119,7 @@ export class Payment {
       value,
       {
         ...options,
+        extraData: extraDataWithPaymentRequestId,
         networkDecimals: decimals.networkDecimals
       }
     )
@@ -132,7 +139,7 @@ export class Payment {
           ),
           utils.convertToHexString(new BigNumber(maxFees.raw)),
           path,
-          extraDataWithReferenceId
+          extraDataWithPaymentRequestId
         ],
         {
           gasLimit: gasLimit
@@ -444,19 +451,19 @@ export class Payment {
     }
   }
 
-  private extendExtraDataByReferenceId(
+  private extendExtraDataByPaymentRequestId(
     extraData: string,
-    referenceId: string = ''
+    paymentRequestId: string = ''
   ): string {
     // TODO:
     // Implement some useful encoding. This here simply makes sure that the
     // String concatenations works.
-    if (!extraData && !referenceId) {
+    if (!extraData && !paymentRequestId) {
       return '0x'
     } else if (!extraData) {
-      return referenceId
+      return paymentRequestId
     } else {
-      return extraData + referenceId
+      return extraData + paymentRequestId
     }
   }
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -78,6 +78,7 @@ export interface PaymentOptions extends TLOptions {
   maximumFees?: number
   feePayer?: FeePayer
   extraData?: string
+  paymentRequestId?: string
 }
 
 export interface TrustlineUpdateOptions extends TLOptions {

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -58,6 +58,7 @@ export const parametrizedTLNetworkConfig = [
 ]
 
 export const extraData = '0x12ab34ef'
+export const referenceId = '1234'
 
 export async function createAndLoadUsers(tlInstances: TLNetwork[]) {
   return Promise.all(

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -58,7 +58,7 @@ export const parametrizedTLNetworkConfig = [
 ]
 
 export const extraData = '0x12ab34ef'
-export const referenceId = '1234'
+export const paymentRequestId = '1234'
 
 export async function createAndLoadUsers(tlInstances: TLNetwork[]) {
   return Promise.all(

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -12,6 +12,7 @@ import {
   deployIdentities,
   extraData,
   parametrizedTLNetworkConfig,
+  referenceId,
   requestEth,
   wait
 } from '../Fixtures'
@@ -190,6 +191,27 @@ describe('e2e', () => {
           expect(preparedPayment.feePayer).to.equal(FeePayer.Receiver)
         })
 
+        it('should prepare tx for trustline with reference id', async () => {
+          const preparedPayment = await tl1.payment.prepare(
+            network.address,
+            user2.address,
+            2.25,
+            {
+              extraData
+            },
+            referenceId
+          )
+
+          expect(preparedPayment).to.have.all.keys(
+            'rawTx',
+            'feePayer',
+            'txFees',
+            'maxFees',
+            'path'
+          )
+          expect(preparedPayment.feePayer).to.equal(FeePayer.Sender)
+        })
+
         it('should not prepare tx for trustline transfer', async () => {
           await expect(
             tl1.payment.prepare(network.address, user2.address, 2000)
@@ -306,7 +328,8 @@ describe('e2e', () => {
             network.address,
             user2.address,
             1.5,
-            { extraData }
+            { extraData },
+            referenceId
           )
           await tl1.payment.confirm(rawTx)
           await wait()
@@ -325,7 +348,7 @@ describe('e2e', () => {
           expect(latestTransfer.counterParty).to.be.equal(tl2.user.address)
           expect(latestTransfer.amount).to.have.keys('decimals', 'raw', 'value')
           expect(latestTransfer.amount.value).to.eq('1.5')
-          expect(latestTransfer.extraData).to.eq(extraData)
+          expect(latestTransfer.extraData).to.eq(extraData + referenceId)
           expect(latestTransfer.blockNumber).to.be.a('number')
           expect(latestTransfer.direction).to.equal('sent')
           expect(latestTransfer.networkAddress).to.be.a('string')

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -12,7 +12,7 @@ import {
   deployIdentities,
   extraData,
   parametrizedTLNetworkConfig,
-  referenceId,
+  paymentRequestId,
   requestEth,
   wait
 } from '../Fixtures'
@@ -191,15 +191,15 @@ describe('e2e', () => {
           expect(preparedPayment.feePayer).to.equal(FeePayer.Receiver)
         })
 
-        it('should prepare tx for trustline with reference id', async () => {
+        it('should prepare tx for trustline with payment request id', async () => {
           const preparedPayment = await tl1.payment.prepare(
             network.address,
             user2.address,
             2.25,
             {
-              extraData
-            },
-            referenceId
+              extraData,
+              paymentRequestId
+            }
           )
 
           expect(preparedPayment).to.have.all.keys(
@@ -328,8 +328,7 @@ describe('e2e', () => {
             network.address,
             user2.address,
             1.5,
-            { extraData },
-            referenceId
+            { extraData, paymentRequestId }
           )
           await tl1.payment.confirm(rawTx)
           await wait()
@@ -348,7 +347,7 @@ describe('e2e', () => {
           expect(latestTransfer.counterParty).to.be.equal(tl2.user.address)
           expect(latestTransfer.amount).to.have.keys('decimals', 'raw', 'value')
           expect(latestTransfer.amount.value).to.eq('1.5')
-          expect(latestTransfer.extraData).to.eq(extraData + referenceId)
+          expect(latestTransfer.extraData).to.eq(extraData + paymentRequestId)
           expect(latestTransfer.blockNumber).to.be.a('number')
           expect(latestTransfer.direction).to.equal('sent')
           expect(latestTransfer.networkAddress).to.be.a('string')


### PR DESCRIPTION
Closes: #344 

The "reference id" is my proposal for a better naming as requested in the issue. It tries to be more generic by just stating that this is an identifier for something that the payment refers to.

The encoding of the id in addition to the client provided extra data is just a dummy function as asked for until there is an actual encoding format defined. So far it simply concatenates both strings.