### PR TITLE
Use id for payment request and decline instead of nonce

### DIFF
--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -51,6 +51,9 @@ export class Messaging {
       options.decimalsOptions || {}
     )
     const type = 'PaymentRequest'
+    // TODO: remove nonce from payment request and request decline once it is not used anymore and turn up number of decimals
+    // number of decimals had to be turned down to have enough precision for nonce == id
+    const randomBigNumber = utils.generateRandomNumber(15)
     const paymentRequest = {
       type,
       networkAddress,
@@ -61,7 +64,8 @@ export class Messaging {
         decimals.networkDecimals
       ),
       subject,
-      nonce: utils.generateRandomNumber(20).toNumber()
+      nonce: randomBigNumber.toNumber(),
+      id: utils.convertToHexString(randomBigNumber)
     }
     await this.provider.postToEndpoint(`messages/${counterPartyAddress}`, {
       type,
@@ -83,18 +87,20 @@ export class Messaging {
   /**
    * Sends a payment request decline message to given `counterParty` and returns created message.
    * @param counterPartyAddress Address of counter party.
-   * @param nonce Nonce of the payment request to decline.
+   * @param id id of the payment request to decline
+   * matches either the nonce as a number or id of a payment request as a hex string.
    * @param subject Optional subject of decline message.
    */
   public async paymentRequestDecline(
     counterPartyAddress: string,
-    nonce: number,
+    id: number | string,
     subject?: string
   ): Promise<PaymentRequestDeclineMessage> {
     const type = 'PaymentRequestDecline'
     const message = {
       type,
-      nonce,
+      nonce: typeof id === 'number' ? id : utils.convertHexStringToNumber(id),
+      id: typeof id === 'string' ? id : utils.convertToHexString(id),
       subject
     }
     await this.provider.postToEndpoint(`messages/${counterPartyAddress}`, {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -207,6 +207,7 @@ export interface PaymentRequestMessage extends Message {
   networkAddress: string
   subject?: string
   nonce: number
+  id: string
   amount: Amount
   counterParty: string
   user: string
@@ -215,6 +216,7 @@ export interface PaymentRequestMessage extends Message {
 export interface PaymentRequestDeclineMessage {
   type: string
   nonce: number
+  id: string
   subject?: string
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -429,6 +429,27 @@ export const convertToHexString = (
 }
 
 /**
+ * Return the number representation of the given hex string.
+ * @param hexString
+ */
+export const convertHexStringToNumber = (hexString: string): number => {
+  if (!hexString.startsWith('0x')) {
+    throw new Error('Provided string does not start with "0x".')
+  }
+
+  const bigNumber = new BigNumber(hexString, 16)
+  const convertedNumber = bigNumber.toNumber()
+
+  if (!new BigNumber(convertedNumber).isEqualTo(bigNumber)) {
+    throw new Error(
+      'Can not convert hexString to number with enough precision.'
+    )
+  }
+
+  return convertedNumber
+}
+
+/**
  * Generates a random number with specified decimals.
  * @param decimals Decimals which determine size of generated number.
  */
@@ -519,6 +540,7 @@ export default {
   convertToAmount,
   convertToHexString,
   convertToDelegationFees,
+  convertHexStringToNumber,
   fetchUrl,
   formatToFeePayer,
   formatEndpoint,

--- a/tests/e2e/Messaging.test.ts
+++ b/tests/e2e/Messaging.test.ts
@@ -3,6 +3,7 @@ import chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { TLNetwork } from '../../src/TLNetwork'
+import utils from '../../src/utils'
 import {
   createAndLoadUsers,
   parametrizedTLNetworkConfig,
@@ -50,6 +51,10 @@ describe('e2e', () => {
           expect(sentPaymentRequest.amount.value).to.equal('10')
           expect(sentPaymentRequest.subject).to.equal('test subject')
           expect(sentPaymentRequest.nonce).to.be.a('number')
+          expect(sentPaymentRequest.id).to.be.a('string')
+          expect(utils.convertToHexString(sentPaymentRequest.nonce)).to.equal(
+            sentPaymentRequest.id
+          )
           expect(sentPaymentRequest.counterParty).to.equal(tl2.user.address)
           expect(sentPaymentRequest.direction).to.equal('sent')
           expect(sentPaymentRequest.user).to.equal(tl1.user.address)
@@ -60,11 +65,12 @@ describe('e2e', () => {
         it('should return sent decline', async () => {
           const declineMessage = await tl1.messaging.paymentRequestDecline(
             tl2.user.address,
-            10,
+            '0x10',
             'test subject'
           )
           expect(declineMessage.type).to.equal('PaymentRequestDecline')
-          expect(declineMessage.nonce).to.equal(10)
+          expect(declineMessage.nonce).to.equal(16)
+          expect(declineMessage.id).to.equal('0x10')
           expect(declineMessage.subject).to.equal('test subject')
         })
       })
@@ -103,7 +109,7 @@ describe('e2e', () => {
           await wait()
           await tl1.messaging.paymentRequestDecline(
             user1.address,
-            paymentRequest.nonce,
+            paymentRequest.id,
             'decline subject'
           )
           await wait()


### PR DESCRIPTION
closes https://github.com/trustlines-protocol/clientlib/issues/347

I lowered the number of decimals of the id to 15 so that the `nonce: number` and `id: string` have the same value. Above 16 decimals, numbers lose precision in javascript.

I tested manually that if a clientlib receives a `nonce: number` generated with 20 digits, it will still be able to produce a `paymentRequestDecline` for that number.

There is a breaking change for the name of the argument of `paymentRequestDecline` changed from `nonce` to `id`. I did not find a way to avoid that.