### PR TITLE
Use MessagePack to encode extraData

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "webpack-cli": "^3.0.8"
   },
   "dependencies": {
+    "@msgpack/msgpack": "^1.12.1",
     "bignumber.js": "7.2.1",
     "ethereumjs-util": "^5.2.0",
     "ethers": "^4.0.23",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/mocha": "^5.2.2",
-    "@types/node": "^10.5.2",
+    "@types/node": "^10.17.21",
     "awesome-typescript-loader": "^5.2.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
@@ -82,7 +82,7 @@
     "tslint-config-prettier": "^1.18.0",
     "typedoc": "^0.16.9",
     "types-ethereumjs-util": "0.0.8",
-    "typescript": "^2.9.2",
+    "typescript": "^3.0.0",
     "webpack": "^4.16.0",
     "webpack-cli": "^3.0.8"
   },

--- a/src/extraData.ts
+++ b/src/extraData.ts
@@ -1,0 +1,54 @@
+import * as msgPack from '@msgpack/msgpack'
+
+export const MSG_PACK_ID = '0x544c4d50' // hex encoded "TLMP" (Trustlines Message Pack)
+
+export interface ExtraData {
+  paymentRequestId?: string
+}
+
+interface ExtraDataEncoding {
+  prId?: ArrayBufferView
+}
+
+export function encode(extraData: ExtraData): string {
+  const { paymentRequestId } = extraData
+  if (!paymentRequestId) {
+    return '0x'
+  } else {
+    const data: ExtraDataEncoding = {}
+    if (paymentRequestId) {
+      data.prId = hexToArray(paymentRequestId)
+    }
+    const enc = msgPack.encode(data)
+    return MSG_PACK_ID + remove0xPrefix(arrayToHex(enc))
+  }
+}
+
+export function decode(encodedExtraData: string): ExtraData {
+  if (encodedExtraData.startsWith(MSG_PACK_ID)) {
+    const extraData: ExtraDataEncoding = msgPack.decode(
+      hexToArray(encodedExtraData.slice(MSG_PACK_ID.length))
+    )
+    return { paymentRequestId: arrayToHex(extraData.prId) }
+  } else {
+    return null
+  }
+}
+
+function remove0xPrefix(hexString) {
+  if (hexString.startsWith('0x')) {
+    return hexString.slice(2)
+  } else {
+    return hexString
+  }
+}
+
+function arrayToHex(a): string {
+  // This requires Buffer, which might not be available on certain platforms.
+  // If this becomes a problem, we should change the impl here.
+  return '0x' + Buffer.from(a).toString('hex')
+}
+
+function hexToArray(h: string) {
+  return Buffer.from(remove0xPrefix(h), 'hex')
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs/Observable'
 import { Observer } from 'rxjs/Observer'
 import JsonRPC from 'simple-jsonrpc-js'
 import NodeWebSocket from 'ws'
+import { decode } from './extraData'
 
 import {
   GAS_LIMIT_IDENTITY_OVERHEAD,

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -58,7 +58,7 @@ export const parametrizedTLNetworkConfig = [
 ]
 
 export const extraData = '0x12ab34ef'
-export const paymentRequestId = '1234'
+export const paymentRequestId = '0x112233445566778899aa'
 
 export async function createAndLoadUsers(tlInstances: TLNetwork[]) {
   return Promise.all(

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -17,6 +17,7 @@ import {
   createAndLoadUsers,
   deployIdentities,
   extraData,
+  paymentRequestId,
   requestEth,
   setTrustlines,
   tlNetworkConfig,
@@ -155,7 +156,7 @@ describe('e2e', () => {
           network2.address,
           user2.address,
           1,
-          { extraData }
+          { paymentRequestId }
         )
         tlTransferTxHash = await tl1.payment.confirm(tlTransferTx.rawTx)
         await wait()
@@ -326,8 +327,8 @@ describe('e2e', () => {
           (tlTransferEvents[0] as NetworkTransferEvent).amount
         ).to.have.keys('raw', 'decimals', 'value')
         expect(
-          (tlTransferEvents[0] as NetworkTransferEvent).extraData
-        ).to.equal(extraData)
+          (tlTransferEvents[0] as NetworkTransferEvent).paymentRequestId
+        ).to.equal(paymentRequestId)
 
         // events thrown on deposit
         const depositEvents = allEvents.filter(
@@ -516,7 +517,7 @@ describe('e2e', () => {
           network1.address,
           user2.address,
           2.5,
-          { extraData }
+          { paymentRequestId }
         )
         await tl1.payment.confirm(rawTx)
         await wait()
@@ -548,7 +549,10 @@ describe('e2e', () => {
         expect(transferEvent).to.have.property('to', user2.address)
         expect(transferEvent).to.have.property('counterParty', user2.address)
         expect(transferEvent).to.have.property('user', user1.address)
-        expect(transferEvent).to.have.property('extraData', extraData)
+        expect(transferEvent).to.have.property(
+          'paymentRequestId',
+          paymentRequestId
+        )
         expect(transferEvent.blockHash).to.be.a('string')
         expect(transferEvent.logIndex).be.a('number')
 

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -197,7 +197,6 @@ describe('e2e', () => {
             user2.address,
             2.25,
             {
-              extraData,
               paymentRequestId
             }
           )
@@ -326,7 +325,7 @@ describe('e2e', () => {
             network.address,
             user2.address,
             1.5,
-            { extraData, paymentRequestId }
+            { paymentRequestId }
           )
           await tl1.payment.confirm(rawTx)
           await wait()
@@ -345,10 +344,8 @@ describe('e2e', () => {
           expect(latestTransfer.counterParty).to.be.equal(tl2.user.address)
           expect(latestTransfer.amount).to.have.keys('decimals', 'raw', 'value')
           expect(latestTransfer.amount.value).to.eq('1.5')
-          expect(latestTransfer.extraData).to.eq(extraData + paymentRequestId)
-          expect(latestTransfer.paymentRequestId).to.eq(
-            extraData + paymentRequestId
-          )
+          expect(latestTransfer.extraData).to.be.a('string')
+          expect(latestTransfer.paymentRequestId).to.eq(paymentRequestId)
           expect(latestTransfer.blockNumber).to.be.a('number')
           expect(latestTransfer.direction).to.equal('sent')
           expect(latestTransfer.networkAddress).to.be.a('string')

--- a/tests/unit/extraData.test.ts
+++ b/tests/unit/extraData.test.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai'
+import 'mocha'
+import { decode, encode } from '../../src/extraData'
+
+describe('unit', () => {
+  describe('extraData', () => {
+    it('should encode and decode correctly', () => {
+      const extraData = { paymentRequestId: '0x1234567890abcdef' }
+      expect(extraData).to.be.deep.eq(decode(encode(extraData)))
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,6 +117,11 @@
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@machinomy/types-safe-buffer/-/types-safe-buffer-0.0.1.tgz#bf80d94a2cc90b9d8438749aa3542dbf7a1f72b0"
 
+"@msgpack/msgpack@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-1.12.1.tgz#aab1084bc33c955501bc0f202099e38304143e0b"
+  integrity sha512-nGwwmkdm3tuLdEkWMIwLBgFBfMFILILxcZIQY0dfqsdboN2iZdKfOYKUOKoa0wXw1FL1PL3yEYGPCXhwodQDTA==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,9 +155,10 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
 
-"@types/node@^10.3.2", "@types/node@^10.5.2":
-  version "10.12.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.21.tgz#7e8a0c34cf29f4e17a36e9bd0ea72d45ba03908e"
+"@types/node@^10.17.21":
+  version "10.17.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.21.tgz#c00e9603399126925806bed2d9a1e37da506965e"
+  integrity sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -313,6 +314,7 @@ acorn@^6.0.5:
 aes-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
 agent-base@5:
   version "5.1.1"
@@ -597,6 +599,7 @@ braces@^2.3.1, braces@^2.3.2:
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -1234,14 +1237,18 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
-elliptic@6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
+elliptic@6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
     hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
     inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
 
 elliptic@^6.0.0, elliptic@^6.2.3:
   version "6.4.1"
@@ -1383,13 +1390,13 @@ ethereumjs-util@^5.2.0:
     secp256k1 "^3.0.1"
 
 ethers@^4.0.23:
-  version "4.0.23"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.23.tgz#930c7b1585241f61b29c262ffd8f21e82721ba30"
+  version "4.0.47"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.47.tgz#91b9cd80473b1136dd547095ff9171bd1fc68c85"
+  integrity sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==
   dependencies:
-    "@types/node" "^10.3.2"
     aes-js "3.0.0"
     bn.js "^4.4.0"
-    elliptic "6.3.3"
+    elliptic "6.5.2"
     hash.js "1.1.3"
     js-sha3 "0.5.7"
     scrypt-js "2.0.4"
@@ -1862,6 +1869,7 @@ hash-base@^3.0.0:
 hash.js@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
+  integrity sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
@@ -2023,13 +2031,18 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+
+inherits@^2.0.1, inherits@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
@@ -2289,6 +2302,7 @@ jquery@^3.4.1:
 js-sha3@0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
+  integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2635,6 +2649,7 @@ mimic-fn@^1.0.0:
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
@@ -3406,8 +3421,9 @@ rechoir@^0.6.2:
     resolve "^1.1.6"
 
 reconnecting-websocket@^4.1.10:
-  version "4.1.10"
-  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-4.1.10.tgz#15485b5c5266ab6dd99187e23e8da207d24c4270"
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz#3b0e5b96ef119e78a03135865b8bb0af1b948783"
+  integrity sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==
 
 regenerator-runtime@^0.10.5:
   version "0.10.5"
@@ -3577,6 +3593,7 @@ schema-utils@^1.0.0:
 scrypt-js@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
+  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
 
 secp256k1@^3.0.1:
   version "3.6.2"
@@ -3638,6 +3655,7 @@ set-value@^2.0.0:
 setimmediate@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.4.tgz#20e81de622d4a02588ce0c8da8973cbcf1d3138f"
+  integrity sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=
 
 setimmediate@^1.0.4:
   version "1.0.5"
@@ -4213,9 +4231,10 @@ typescript@3.7.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
-typescript@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@^3.0.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
   version "3.6.5"
@@ -4322,6 +4341,7 @@ util@^0.11.0:
 uuid@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"
+  integrity sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
 
 uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
@@ -4501,6 +4521,7 @@ ws@^6.2.1:
 xmlhttprequest@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
+  integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Use MessagePack to encode the extraData of a Transfer. This is so far
only the paymentRequestId. I chose to simply use bytes as the datatype
for now, but that might change later, and we might want to use a custom
type.
The attaching of the decoded paymentRequestId had to be moved, so that
it will be encluded in every endpoint where Transfers are received.
At the moment it can not handle the old extraData and paymentRequestId
at the same time. This is due to the unclear behaviour of what extraData
on the receiver side should contain, if both were included.

Closes #358 