### PR TITLE
Catch error raised by msgPack.decode when format is not recognised

### DIFF
--- a/src/extraData.ts
+++ b/src/extraData.ts
@@ -30,16 +30,29 @@ export function encode(extraData: ExtraData): string {
 }
 
 export function decode(encodedExtraData: string): ExtraData {
-  if (encodedExtraData.startsWith(MSG_PACK_ID)) {
-    const extraData: ExtraDataEncoding = msgPack.decode(
-      hexToArray(encodedExtraData.slice(MSG_PACK_ID.length))
-    )
-    return {
-      paymentRequestId: arrayToHex(extraData.prId),
-      messageId: arrayToHex(extraData.mgId)
-    }
-  } else {
+  if (!encodedExtraData.startsWith(MSG_PACK_ID)) {
     return null
+  }
+
+  const encodedExtraDataArray = hexToArray(
+    encodedExtraData.slice(MSG_PACK_ID.length)
+  )
+
+  let extraData: ExtraDataEncoding
+  try {
+    extraData = msgPack.decode(encodedExtraDataArray)
+  } catch (error) {
+    if (error instanceof RangeError) {
+      // The encodedExtraData starts with MSG_PACK_ID but does not follow the expected format
+      return null
+    } else {
+      throw error
+    }
+  }
+
+  return {
+    paymentRequestId: arrayToHex(extraData.prId),
+    messageId: arrayToHex(extraData.mgId)
   }
 }
 

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -498,7 +498,10 @@ describe('e2e', () => {
             network.address,
             user3.address,
             transferValue,
-            { extraData, addMessageId: false }
+            {
+              extraData,
+              addMessageId: false
+            }
           )
           await tl1.payment.confirm(transfer.rawTx)
           await wait()

--- a/tests/unit/extraData.test.ts
+++ b/tests/unit/extraData.test.ts
@@ -25,5 +25,11 @@ describe('unit', () => {
       }
       expect(extraData).to.be.deep.eq(decode(encode(extraData)))
     })
+
+    it('should not get an error when decoding wrongly formed extra data', () => {
+      const encodedExtraData = '0x544c4d501' + '12345678'.repeat(10)
+      const decoded = decode(encodedExtraData)
+      expect(decoded).to.equal(null)
+    })
   })
 })


### PR DESCRIPTION
Instead of throwing an error, return null when decoding failed
closes https://github.com/trustlines-protocol/clientlib/issues/368