### PR TITLE
Decode extra data of transfer details

### DIFF
--- a/src/Event.ts
+++ b/src/Event.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs/Observable'
 import { fromPromise } from 'rxjs/observable/fromPromise'
 
 import { CurrencyNetwork } from './CurrencyNetwork'
-import { decode } from './extraData'
+import { decode, processExtraData } from './extraData'
 import { TLProvider } from './providers/TLProvider'
 import { User } from './User'
 
@@ -250,19 +250,4 @@ export class Event {
       return result
     }, {})
   }
-}
-
-/**
- * Processes the content of extraData and attaches the content to the event.
- * @param event
- */
-function processExtraData(event) {
-  if (event.extraData) {
-    const extraData = decode(event.extraData)
-    if (extraData) {
-      event.paymentRequestId = extraData.paymentRequestId
-      event.messageId = extraData.messageId
-    }
-  }
-  return event
 }

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -2,7 +2,11 @@ import { BigNumber } from 'bignumber.js'
 
 import { CurrencyNetwork } from './CurrencyNetwork'
 import { Event } from './Event'
-import { encode as encodeExtraData } from './extraData'
+import {
+  decode,
+  encode as encodeExtraData,
+  processExtraData
+} from './extraData'
 import { TLProvider } from './providers/TLProvider'
 import {
   GAS_LIMIT_IDENTITY_OVERHEAD,
@@ -488,7 +492,7 @@ export class Payment {
     transferInformation: TransferDetailsRaw,
     networkDecimals: number
   ): TransferDetails {
-    return {
+    const transferDetails = {
       path: transferInformation.path,
       currencyNetwork: transferInformation.currencyNetwork,
       value: utils.formatToAmount(transferInformation.value, networkDecimals),
@@ -502,6 +506,7 @@ export class Payment {
       ),
       extraData: transferInformation.extraData
     }
+    return processExtraData(transferDetails)
   }
 }
 

--- a/src/extraData.ts
+++ b/src/extraData.ts
@@ -60,3 +60,21 @@ function arrayToHex(a): string {
 function hexToArray(h: string) {
   return Buffer.from(remove0xPrefix(h), 'hex')
 }
+
+/**
+ * Processes the content of extraData and attaches the content to the object.
+ * @param object An object potentially having extra data to process
+ */
+export function processExtraData(object) {
+  if (object.extraData !== undefined) {
+    const decodedExtraData = decode(object.extraData)
+
+    object.paymentRequestId = decodedExtraData
+      ? decodedExtraData.paymentRequestId || null
+      : null
+    object.messageId = decodedExtraData
+      ? decodedExtraData.messageId || null
+      : null
+  }
+  return object
+}

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -136,8 +136,8 @@ export interface NetworkTransferEventRaw extends NetworkEvent {
 export interface NetworkTransferEvent extends NetworkEvent {
   amount: Amount
   extraData: string
-  paymentRequestId?: string
-  messageId?: string
+  paymentRequestId: string
+  messageId: string
 }
 
 export interface NetworkTrustlineUpdateEventRaw extends NetworkEvent {
@@ -696,6 +696,8 @@ export interface TransferDetails {
   totalFees: Amount
   feesPaid: Amount[]
   extraData: string
+  paymentRequestId: string
+  messageId: string
 }
 
 export interface TransferIdentifier {

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -98,6 +98,8 @@ describe('e2e', () => {
         expect(last.amount).to.have.keys('raw', 'value', 'decimals')
         expect(last.amount.value).to.eq('1.5')
         expect(last.extraData).to.eq(extraData)
+        expect(last.messageId).to.be.a('null')
+        expect(last.paymentRequestId).to.be.a('null')
         expect(last.logIndex).to.be.a('number')
         expect(last.blockHash).to.be.a('string')
       })
@@ -108,6 +110,7 @@ describe('e2e', () => {
       let acceptTxHash
       let cancelUpdateTxHash
       let tlTransferTxHash
+      let tlTransferMessageId
       let depositTxHash
       let withdrawTxHash
       let transferTxHash
@@ -161,6 +164,7 @@ describe('e2e', () => {
           1,
           { paymentRequestId }
         )
+        tlTransferMessageId = tlTransferTx.messageId
         tlTransferTxHash = await tl1.payment.confirm(tlTransferTx.rawTx)
         await wait()
 
@@ -307,6 +311,7 @@ describe('e2e', () => {
           ({ transactionHash }) => transactionHash === tlTransferTxHash
         )
         // check event Trustlines Transfer
+        console.log(tlTransferEvents[0])
         expect(
           tlTransferEvents,
           'Trustline Transfer should exist'
@@ -334,7 +339,7 @@ describe('e2e', () => {
         ).to.equal(paymentRequestId)
         expect(
           (tlTransferEvents[0] as NetworkTransferEvent).messageId
-        ).to.equal(null)
+        ).to.equal(tlTransferMessageId)
 
         // events thrown on deposit
         const depositEvents = allEvents.filter(

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -441,8 +441,8 @@ describe('e2e', () => {
             user3.address,
             transferValue,
             {
-              extraData,
-              addMessageId: false
+              addMessageId: true,
+              paymentRequestId
             }
           )
           const txHash = await tl1.payment.confirm(transfer.rawTx)
@@ -461,7 +461,9 @@ describe('e2e', () => {
             'feePayer',
             'totalFees',
             'feesPaid',
-            'extraData'
+            'extraData',
+            'paymentRequestId',
+            'messageId'
           )
           expect(transferDetails.path).to.be.an('Array')
           expect(transferDetails.path).to.deep.equal([
@@ -488,7 +490,9 @@ describe('e2e', () => {
           expect(transferDetails.feesPaid[0].value).to.equal(
             transferDetails.totalFees.value
           )
-          expect(transferDetails.extraData).to.equal(extraData)
+          expect(transferDetails.extraData).to.be.a('string')
+          expect(transferDetails.paymentRequestId).to.equal(paymentRequestId)
+          expect(transferDetails.messageId).to.equal(transfer.messageId)
         })
 
         it('should return details for transfer via id', async () => {
@@ -498,7 +502,10 @@ describe('e2e', () => {
             network.address,
             user3.address,
             transferValue,
-            { extraData, addMessageId: false }
+            {
+              extraData,
+              addMessageId: false
+            }
           )
           await tl1.payment.confirm(transfer.rawTx)
           await wait()
@@ -518,7 +525,9 @@ describe('e2e', () => {
             'feePayer',
             'totalFees',
             'feesPaid',
-            'extraData'
+            'extraData',
+            'paymentRequestId',
+            'messageId'
           )
           expect(transferDetails.path).to.be.an('Array')
           expect(transferDetails.path).to.deep.equal([
@@ -546,6 +555,8 @@ describe('e2e', () => {
             transferDetails.totalFees.value
           )
           expect(transferDetails.extraData).to.equal('0x12ab34ef')
+          expect(transferDetails.paymentRequestId).to.be.a('null')
+          expect(transferDetails.messageId).to.be.a('null')
         })
       })
 


### PR DESCRIPTION
Always return paymentRequestId and messageId for transfer details
and transfer events, return null when there is none instead of
undefined.

closes https://github.com/trustlines-protocol/clientlib/issues/369