### PR TITLE
Increase the decimals used for payment request id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Deprecates function `Payment.confirm`, use `Payment.confirmPayment` instead
 
+### Removed
+
+- Removed the field `nonce` from payment requests and declines, use `id` instead
+
 ## [0.13.0] - 2020-04-23
 
 (requires relay version >=0.15.0)

--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -52,9 +52,8 @@ export class Messaging {
       options.decimalsOptions || {}
     )
     const type = 'PaymentRequest'
-    // TODO: remove nonce from payment request and request decline once it is not used anymore and turn up number of decimals
-    // number of decimals had to be turned down to have enough precision for nonce == id
-    const randomBigNumber = utils.generateRandomNumber(15)
+    // 19 decimals make the number fit into 64 bits
+    const id = utils.convertToHexString(utils.generateRandomNumber(19))
     const paymentRequest = {
       type,
       networkAddress,
@@ -65,8 +64,7 @@ export class Messaging {
         decimals.networkDecimals
       ),
       subject,
-      nonce: randomBigNumber.toNumber(),
-      id: utils.convertToHexString(randomBigNumber)
+      id
     }
     const message = {
       ...paymentRequest,
@@ -93,14 +91,13 @@ export class Messaging {
    */
   public async paymentRequestDecline(
     counterPartyAddress: string,
-    id: number | string,
+    id: string,
     subject?: string
   ): Promise<PaymentRequestDeclineMessage> {
     const type = 'PaymentRequestDecline'
     const message = {
       type,
-      nonce: typeof id === 'number' ? id : utils.convertHexStringToNumber(id),
-      id: typeof id === 'string' ? id : utils.convertToHexString(id),
+      id,
       subject
     }
     await this.sendMessage(counterPartyAddress, type, message)

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -214,7 +214,6 @@ interface Message {
 export interface PaymentRequestMessage extends Message {
   networkAddress: string
   subject?: string
-  nonce: number
   id: string
   amount: Amount
   counterParty: string
@@ -223,7 +222,6 @@ export interface PaymentRequestMessage extends Message {
 
 export interface PaymentRequestDeclineMessage {
   type: string
-  nonce: number
   id: string
   subject?: string
 }

--- a/tests/e2e/Messaging.test.ts
+++ b/tests/e2e/Messaging.test.ts
@@ -50,11 +50,7 @@ describe('e2e', () => {
           )
           expect(sentPaymentRequest.amount.value).to.equal('10')
           expect(sentPaymentRequest.subject).to.equal('test subject')
-          expect(sentPaymentRequest.nonce).to.be.a('number')
           expect(sentPaymentRequest.id).to.be.a('string')
-          expect(utils.convertToHexString(sentPaymentRequest.nonce)).to.equal(
-            sentPaymentRequest.id
-          )
           expect(sentPaymentRequest.counterParty).to.equal(tl2.user.address)
           expect(sentPaymentRequest.direction).to.equal('sent')
           expect(sentPaymentRequest.user).to.equal(tl1.user.address)
@@ -69,7 +65,6 @@ describe('e2e', () => {
             'test subject'
           )
           expect(declineMessage.type).to.equal('PaymentRequestDecline')
-          expect(declineMessage.nonce).to.equal(16)
           expect(declineMessage.id).to.equal('0x10')
           expect(declineMessage.subject).to.equal('test subject')
         })
@@ -159,7 +154,7 @@ describe('e2e', () => {
         it('should receive payment requests decline', async () => {
           expect(messages[2]).to.have.property('type', 'PaymentRequestDecline')
           expect(messages[2].timestamp).to.be.a('number')
-          expect(messages[2].nonce).to.be.a('number')
+          expect(messages[2].id).to.be.a('string')
           expect(messages[2]).to.have.property('subject', 'decline subject')
         })
 


### PR DESCRIPTION
Increased from 15 to 19.
The nonce is also removed from payment requests and declines as it
was the reason we had to keep the decimals at 15.