### PR TITLE
Push tagged version of e2e tests to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           paths:
             - images
 
-  deploy-e2e-image:
+  deploy-latest-e2e-image:
     <<: *defaults
     environment:
       DOCKER_REPO: trustlines/e2e
@@ -133,6 +133,29 @@ jobs:
           command: |
             docker tag $LOCAL_IMAGE $DOCKER_REPO:latest
             docker push $DOCKER_REPO:latest
+
+  deploy-tag-e2e-image:
+    <<: *defaults
+    environment:
+      DOCKER_REPO: trustlines/e2e
+      LOCAL_IMAGE: e2e
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: "~"
+      - run:
+          name: Load docker image
+          command: |
+            docker load --input ~/images/$LOCAL_IMAGE.tar
+      - run:
+          name: Login to dockerhub
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+      - run:
+          name: Upload tag $CIRCLE_TAG
+          command: |
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:$CIRCLE_TAG
+            docker push $DOCKER_REPO:$CIRCLE_TAG
 
   run-end2end-tests:
     <<: *defaults
@@ -185,8 +208,11 @@ workflows:
   version: 2
   default:
     jobs:
-      - build-e2e-image
-      - deploy-e2e-image:
+      - build-e2e-image:
+          filters:
+            tags:
+              only: /^v.*/
+      - deploy-latest-e2e-image:
           context: docker-credentials
           requires:
             - build-e2e-image
@@ -194,9 +220,22 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy-tag-e2e-image:
+          context: docker-credentials
+          requires:
+            - build-e2e-image
+            - run-end2end-tests
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
       - run-end2end-tests:
           requires:
             - build-e2e-image
+          filters:
+            tags:
+              only: /^v.*/
       - build:
           filters:
             tags:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustlines-clientlib",
-  "version": "0.13.1-0",
+  "version": "0.13.5-0",
   "description": "Javascript library for interacting with the trustlines network protocol",
   "main": "lib-esm/TLNetwork.js",
   "scripts": {


### PR DESCRIPTION
To be able to run older e2e tests for out backwards compatibility
tests, we need to push tagged versions to
docker hub.