### PR TITLE
Add method for creating a trustline request invite link

### DIFF
--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -10,7 +10,7 @@ import {
 } from './Transaction'
 import { User } from './User'
 
-import utils from './utils'
+import utils, { defaultBaseUrl } from './utils'
 
 import {
   AnyNetworkTrustlineEvent,
@@ -598,6 +598,53 @@ export class Trustline {
       path,
       value: utils.formatToAmount(value, decimals.networkDecimals)
     }
+  }
+
+  /**
+   * Builds an invite link for a trustline request in the format
+   * ```
+   * <BASE_URL>/trustlinerequest/:networkAddress/:creditlineGiven/:creditlineReceived/:interestRateGiven/:interestRateReceived[?:optionalParams]
+   * ```
+   * @param networkAddress Address of currency network.
+   * @param amounts Amounts to use for the trustline request.
+   * @param amounts.creditlineGiven Credit limit set for receiver. Denominated in "normal" units.
+   * @param amounts.creditlineReceived Credit limit set for sender. Denominated in "normal" units.
+   * @param amounts.interestRateGiven Optional interest rate for receiver if allowed in currency network. Denominated in % per year.
+   * @param amounts.interestRateReceived Optional interest rate for sender if allowed in currency network. Denominated in % per year.
+   * @param options Additional options for link creation.
+   * @param options.customBase Optional custom base for link.
+   * @param options[key] Any other additional query param that should added to the trustline request link like `<TRUSTLINE_REQUEST_LINK>?key=value`.
+   */
+  public async buildTrustlineRequestInviteLink(
+    networkAddress: string,
+    amounts: {
+      creditlineGiven: string | number
+      creditlineReceived: string | number
+      interestRateGiven?: string | number
+      interestRateReceived?: string | number
+    },
+    options?: {
+      [key: string]: string
+      customBase?: string
+    }
+  ): Promise<string> {
+    const {
+      creditlineGiven,
+      creditlineReceived,
+      interestRateGiven = '0',
+      interestRateReceived = '0'
+    } = amounts
+    const { customBase, ...rest } = options || {}
+    const path = [
+      'trustlinerequest',
+      networkAddress,
+      String(creditlineGiven),
+      String(creditlineReceived),
+      String(interestRateGiven),
+      String(interestRateReceived)
+    ]
+
+    return utils.buildUrl(customBase || defaultBaseUrl, { path, query: rest })
   }
 
   /**

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -10,7 +10,7 @@ import {
 } from './Transaction'
 import { User } from './User'
 
-import utils, { defaultBaseUrl } from './utils'
+import utils from './utils'
 
 import {
   AnyNetworkTrustlineEvent,
@@ -644,7 +644,7 @@ export class Trustline {
       String(interestRateReceived)
     ]
 
-    return utils.buildUrl(customBase || defaultBaseUrl, { path, query: rest })
+    return utils.buildUrl(customBase, { path, query: rest })
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ export const websocketStream = (
  *        options.query - the query part of the URL
  */
 export const buildUrl = (
-  baseUrl: string,
+  baseUrl: string = defaultBaseUrl,
   options?: { path?: string[]; query?: object }
 ): string => {
   // typescript bug: https://github.com/microsoft/TypeScript/issues/26235

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -260,5 +260,45 @@ describe('unit', () => {
         assert.hasAllKeys(closeTx, ['txFees', 'maxFees', 'path', 'rawTx'])
       })
     })
+
+    describe('#buildTrustlineRequestInviteLink()', () => {
+      beforeEach(() => init())
+
+      it('should build a default link', async () => {
+        const link = await trustline.buildTrustlineRequestInviteLink(
+          FAKE_NETWORK.address,
+          {
+            creditlineGiven: 100,
+            creditlineReceived: 100
+          }
+        )
+        assert.equal(
+          link,
+          `trustlines://trustlinerequest/${FAKE_NETWORK.address}/100/100/0/0`
+        )
+      })
+
+      it('should build a link with custom base, interest rates and additional query params', async () => {
+        const link = await trustline.buildTrustlineRequestInviteLink(
+          FAKE_NETWORK.address,
+          {
+            creditlineGiven: 123,
+            creditlineReceived: 321,
+            interestRateGiven: 1.1,
+            interestRateReceived: 2.1
+          },
+          {
+            customBase: 'https://custombase',
+            username: 'SenderUsername'
+          }
+        )
+        assert.equal(
+          link,
+          `https://custombase/trustlinerequest/${
+            FAKE_NETWORK.address
+          }/123/321/1.1/2.1?username=SenderUsername`
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
This method creates a link, which can be shared off-chain, inviting the receiver to create a trustline request with the specified parameters.

The app wants to use these links, for example, to create dynamic links and improve the onboarding experience for new users.

Related to https://github.com/trustlines-network/ppm-app-project/issues/317