### PR TITLE
Add user address to trustlines request invitation

### DIFF
--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -603,7 +603,7 @@ export class Trustline {
   /**
    * Builds an invite link for a trustline request in the format
    * ```
-   * <BASE_URL>/trustlinerequest/:networkAddress/:creditlineGiven/:creditlineReceived/:interestRateGiven/:interestRateReceived[?:optionalParams]
+   * <BASE_URL>/trustlinerequest/:networkAddress/:senderAddress/:creditlineGiven/:creditlineReceived/:interestRateGiven/:interestRateReceived[?:optionalParams]
    * ```
    * @param networkAddress Address of currency network.
    * @param amounts Amounts to use for the trustline request.
@@ -638,6 +638,7 @@ export class Trustline {
     const path = [
       'trustlinerequest',
       networkAddress,
+      await this.user.getAddress(),
       String(creditlineGiven),
       String(creditlineReceived),
       String(interestRateGiven),

--- a/tests/unit/Trustline.test.ts
+++ b/tests/unit/Trustline.test.ts
@@ -272,9 +272,13 @@ describe('unit', () => {
             creditlineReceived: 100
           }
         )
+        const userAddress = await fakeUser.getAddress()
+
         assert.equal(
           link,
-          `trustlines://trustlinerequest/${FAKE_NETWORK.address}/100/100/0/0`
+          `trustlines://trustlinerequest/${
+            FAKE_NETWORK.address
+          }/${userAddress}/100/100/0/0`
         )
       })
 
@@ -292,11 +296,13 @@ describe('unit', () => {
             username: 'SenderUsername'
           }
         )
+        const userAddress = await fakeUser.getAddress()
+
         assert.equal(
           link,
           `https://custombase/trustlinerequest/${
             FAKE_NETWORK.address
-          }/123/321/1.1/2.1?username=SenderUsername`
+          }/${userAddress}/123/321/1.1/2.1?username=SenderUsername`
         )
       })
     })


### PR DESCRIPTION
The method did not include the address of the sender in URL.