### PR TITLE
Add function in identity wallet to update identity implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "reconnecting-websocket": "^4.1.10",
     "rxjs": "^5.4.1",
     "simple-jsonrpc-js": "0.0.10",
-    "trustlines-contracts-abi": "dev",
+    "trustlines-contracts-abi": "^1.1.6-dev2.gdad274b",
     "typedoc-plugin-markdown": "^2.2.16",
     "ws": "^6.2.1"
   }

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -45,10 +45,30 @@ export class RelayProvider extends Provider implements TLProvider {
    * @returns the next nonce that should be used for making a meta-transaction
    */
   public async getIdentityNonce(address: string): Promise<number> {
-    const { identity, nextNonce, balance } = await this.fetchEndpoint<any>(
-      `/identities/${address}`
-    )
+    const {
+      identity,
+      nextNonce,
+      balance,
+      implementationAddress
+    } = await this.fetchEndpoint<any>(`/identities/${address}`)
     return nextNonce
+  }
+
+  /**
+   * Returns implementation address of identity with given address
+   * @param address Address of identity
+   * @returns the implementation address currently in use by the given identity
+   */
+  public async getIdentityImplementationAddress(
+    address: string
+  ): Promise<string> {
+    const {
+      identity,
+      nextNonce,
+      balance,
+      implementationAddress
+    } = await this.fetchEndpoint<any>(`/identities/${address}`)
+    return implementationAddress
   }
 
   /**

--- a/src/providers/TLProvider.ts
+++ b/src/providers/TLProvider.ts
@@ -26,6 +26,7 @@ export interface TLProvider {
   getTxInfos(userAddress: string): Promise<TxInfos>
   getTxStatus(txHash: string): Promise<TransactionStatusObject>
   getIdentityNonce(userAddress: string): Promise<number>
+  getIdentityImplementationAddress(userAddress: string): Promise<string>
   getMetaTxFees(metaTransaction: MetaTransaction): Promise<MetaTransactionFees>
   getMetaTxStatus(
     identityAddress: string,

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -160,6 +160,17 @@ export class IdentityWallet implements TLWallet {
     }
   }
 
+  public async isIdentityImplementationUpToDate(): Promise<boolean> {
+    return (
+      (await this.getIdentityImplementationAddress()) ===
+      this.identityImplementationAddress
+    )
+  }
+
+  public async getIdentityImplementationAddress(): Promise<string> {
+    return this.provider.getIdentityImplementationAddress(this.address)
+  }
+
   /**
    * Loads given wallet data of type `identity`.
    * @param walletData Wallet data of type `identity`.

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -10,6 +10,8 @@ import {
 } from './TLWallet'
 import { WalletFromEthers } from './WalletFromEthers'
 
+import { Transaction } from '../Transaction'
+
 import {
   Amount,
   DeployIdentityResponse,
@@ -21,7 +23,9 @@ import {
   Signature,
   TransactionStatusObject,
   TxFeesRaw,
-  TxObjectRaw
+  TxObjectInternal,
+  TxObjectRaw,
+  TxOptionsInternal
 } from '../typings'
 
 import utils from '../utils'
@@ -46,7 +50,7 @@ export class IdentityWallet implements TLWallet {
   private identityImplementationAddress: string
   private nonceMechanism: NonceMechanism
   private chainId: number
-  private identityVersion = 1
+  private metaTransactionVersion = 1
 
   constructor(
     provider: TLProvider,
@@ -416,7 +420,7 @@ export class IdentityWallet implements TLWallet {
       data: rawTx.data || '0x',
       from: rawTx.from,
       chainId: this.chainId,
-      version: this.identityVersion,
+      version: this.metaTransactionVersion,
       nonce: rawTx.nonce.toString(),
       to: rawTx.to,
       value: rawTx.value.toString(),
@@ -444,6 +448,21 @@ export class IdentityWallet implements TLWallet {
           `Can not generate nonce for unknown mechanism: ${this.nonceMechanism}`
         )
     }
+  }
+
+  public async prepareImplementationUpdate(
+    transaction: Transaction,
+    options: TxOptionsInternal = {}
+  ): Promise<TxObjectInternal> {
+    // TODO: maybe check that the implementation actually needs updating?
+    return transaction.prepareContractTransaction(
+      this.address,
+      this.address,
+      'Identity',
+      'changeImplementation',
+      [this.identityImplementationAddress],
+      options
+    )
   }
 
   /**

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -311,7 +311,6 @@ describe('e2e', () => {
           ({ transactionHash }) => transactionHash === tlTransferTxHash
         )
         // check event Trustlines Transfer
-        console.log(tlTransferEvents[0])
         expect(
           tlTransferEvents,
           'Trustline Transfer should exist'

--- a/tests/e2e/Identity.test.ts
+++ b/tests/e2e/Identity.test.ts
@@ -72,6 +72,7 @@ describe('e2e', () => {
 
     describe('Update identity', () => {
       let newIdentityWallet
+      let newIdentityImplementation
 
       before(async () => {
         // make sure we have a wallet with a proper implementation and deployed identity
@@ -80,8 +81,7 @@ describe('e2e', () => {
         await identityWallet.deployIdentity()
 
         // Use arbitrary address for new implementation
-        const newIdentityImplementation =
-          '0x1234567812345678123456781234567812345678'
+        newIdentityImplementation = '0x1234567812345678123456781234567812345678'
         // create a new identity with a different implementation address
         newIdentityWallet = new IdentityWallet(
           relayProvider,
@@ -91,6 +91,13 @@ describe('e2e', () => {
           NonceMechanism.Random
         )
         await newIdentityWallet.loadFrom(walletData)
+
+        expect(
+          await newIdentityWallet.getIdentityImplementationAddress()
+        ).to.equal(identityImplementationAddress)
+        expect(
+          await newIdentityWallet.isIdentityImplementationUpToDate()
+        ).to.equal(false)
       })
 
       it('should prepare an update of identity implementation', async () => {
@@ -154,6 +161,13 @@ describe('e2e', () => {
         const balance = await identityWallet.getBalance()
         assert.hasAllKeys(balance, AMOUNT_KEYS)
         expect(balance.value).to.equal('0')
+      })
+
+      it('should get identity implementation address', async () => {
+        const implementationAddress = await identityWallet.getIdentityImplementationAddress()
+        expect(implementationAddress).to.equal(
+          tlNetworkConfigIdentity.identityImplementationAddress
+        )
       })
 
       it('should increase balance of identity contract', async () => {

--- a/tests/helpers/FakeTLProvider.ts
+++ b/tests/helpers/FakeTLProvider.ts
@@ -12,7 +12,8 @@ import {
   FAKE_TX_HASH,
   FAKE_TX_INFOS,
   FAKE_USER,
-  FAKE_USER_ADDRESSES
+  FAKE_USER_ADDRESSES,
+  identityImplementationAddress
 } from '../Fixtures'
 
 import { AddressZero } from 'ethers/constants'
@@ -148,6 +149,12 @@ export class FakeTLProvider implements TLProvider {
 
   public async getIdentityNonce(userAddress: string): Promise<number> {
     return Promise.resolve(123)
+  }
+
+  public async getIdentityImplementationAddress(
+    userAddress: string
+  ): Promise<string> {
+    return Promise.resolve(identityImplementationAddress)
   }
 
   public async getMetaTxFees(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,10 +4106,10 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-trustlines-contracts-abi@dev:
-  version "0.10.2-dev25.g9ffbd52"
-  resolved "https://registry.yarnpkg.com/trustlines-contracts-abi/-/trustlines-contracts-abi-0.10.2-dev25.g9ffbd52.tgz#4d86a1c97b821db8134f1e6aed9aa8dac34cdee8"
-  integrity sha512-GvHreF/sHvgIgwfR9SlYvM3bMfVS9XvIjkIZgIXFnBoiZt6zjnduVxuKFT8T5vkEuwJVF2wxEBVzEKSlrm1uZA==
+trustlines-contracts-abi@^1.1.6-dev2.gdad274b:
+  version "1.1.6-dev2.gdad274b"
+  resolved "https://registry.yarnpkg.com/trustlines-contracts-abi/-/trustlines-contracts-abi-1.1.6-dev2.gdad274b.tgz#83d9b160fd99e17f026068b864d5b901e0d3a345"
+  integrity sha512-TvvblqXwnwUYByM3ZF24duR43uJuJyXyBMYl59SyCxyQr5mCf6YaYo8cLpISSHD6bao5F3JnCMuiUMfXug7+fw==
 
 ts-node@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
Is it enough for the mobile app to have a function in the identity wallet to do this, or does it need a function in something like `User` or `TLNetwork`?

How do we want the user to know whether he should update or not (whether he already has the same implementation address on the contract on chain and in the identityWallet of the clientlib)?
We can either make a relay endpoint to ask for the value of `identityImplementation` for the identity proxy, or we can save the last used value of identity implementation somehow in the app.

closes https://github.com/trustlines-network/project/issues/884