### PR TITLE
Add script that filters the packed abi to make bundle smaller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:10.15
+    - image: circleci/node:14.11
 
 commands:
   yarn-install:

--- a/filterContracts/filterContracts.js
+++ b/filterContracts/filterContracts.js
@@ -1,0 +1,17 @@
+import * as TrustlinesContractsAbi from 'trustlines-contracts-abi'
+import { writeFile } from 'fs'
+
+const requiredContracts = ['CurrencyNetwork', 'Exchange', 'Identity', 'UnwEth']
+const pathContractsModule =
+  'node_modules/trustlines-contracts-abi/contracts.json'
+
+const filteredAbi = Object.fromEntries(
+  Object.entries(TrustlinesContractsAbi['default']).filter(([key, value]) =>
+    requiredContracts.includes(key)
+  )
+)
+const stringAbi = JSON.stringify(filteredAbi)
+
+writeFile(pathContractsModule, stringAbi, function(err, result) {
+  if (err) console.log('error', err)
+})

--- a/filterContracts/package.json
+++ b/filterContracts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript library for interacting with the trustlines network protocol",
   "main": "lib-esm/TLNetwork.js",
   "scripts": {
-    "build": "tsc && tsc -m es6 --outDir lib-esm && webpack",
+    "build": "node filterContracts/filterContracts.js && tsc && tsc -m es6 --outDir lib-esm && webpack",
     "build:esm": "tsc -m es6 --outDir lib-esm",
     "doc": "typedoc --options tdconfig.json",
     "lint": "tslint -c tslint.json './src/**/**.ts' './tests/**/**.ts'",

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs/Observable'
 import { fromPromise } from 'rxjs/observable/fromPromise'
 
 import { CurrencyNetwork } from './CurrencyNetwork'
-import { decode, processExtraData } from './extraData'
+import { processExtraData } from './extraData'
 import { TLProvider } from './providers/TLProvider'
 import { User } from './User'
 

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -2,11 +2,7 @@ import { BigNumber } from 'bignumber.js'
 
 import { CurrencyNetwork } from './CurrencyNetwork'
 import { Event } from './Event'
-import {
-  decode,
-  encode as encodeExtraData,
-  processExtraData
-} from './extraData'
+import { encode as encodeExtraData, processExtraData } from './extraData'
 import { TLProvider } from './providers/TLProvider'
 import {
   GAS_LIMIT_IDENTITY_OVERHEAD,

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -6,12 +6,9 @@ import * as TrustlinesContractsAbi from 'trustlines-contracts-abi'
 import { TLProvider } from './providers/TLProvider'
 import { TLSigner } from './signers/TLSigner'
 
-import utils, { convertToDelegationFees } from './utils'
+import utils from './utils'
 
 import {
-  Amount,
-  DelegationFeesInternal,
-  MetaTransactionFees,
   PaidDelegationFeesRaw,
   RawTxObject,
   TransactionStatusObject,

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -22,7 +22,6 @@ import {
   EventFilterOptions,
   FeePayer,
   isFeePayerValue,
-  NetworkEvent,
   NetworkTrustlineBalanceUpdate,
   NetworkTrustlineCancelEvent,
   NetworkTrustlineUpdateEvent,

--- a/src/signers/Web3Signer.ts
+++ b/src/signers/Web3Signer.ts
@@ -5,7 +5,6 @@ import { TLSigner } from './TLSigner'
 
 import * as utils from '../utils'
 
-import { utils as ethersUtils } from 'ethers/ethers'
 import {
   Amount,
   MetaTransactionFees,
@@ -20,8 +19,6 @@ import {
  * The Web3Signer class contains functions for signing transactions with a web3 provider.
  */
 export class Web3Signer implements TLSigner {
-  public address: string
-
   private signer: ethers.providers.JsonRpcSigner
   private web3Provider: ethers.providers.Web3Provider
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,12 +7,7 @@ import { Observable } from 'rxjs/Observable'
 import { Observer } from 'rxjs/Observer'
 import JsonRPC from 'simple-jsonrpc-js'
 import NodeWebSocket from 'ws'
-import { decode } from './extraData'
 
-import {
-  GAS_LIMIT_IDENTITY_OVERHEAD,
-  GAS_LIMIT_MULTIPLIER
-} from './Transaction'
 import {
   Amount,
   AmountInternal,


### PR DESCRIPTION
It reduces the size of `_bundles` from 1332kB to 1004kB.
I am not really sure if that is clean, or if that is all that is needed for https://github.com/trustlines-protocol/clientlib/issues/192?