### PR TITLE
Update address used in User.ts to getAddress()

### DIFF
--- a/src/User.ts
+++ b/src/User.ts
@@ -39,7 +39,7 @@ export class User {
   }
 
   /**
-   * Checksummed Ethereum address of currently loaded user/wallet.
+   * Checksummed Ethereum address of currently loaded wallet.
    */
   public get address(): string {
     return this.wallet.address
@@ -205,12 +205,12 @@ export class User {
    *        options.name - convention for a name for the user
    *        options[key] - any other additional options that should be added to the URL
    */
-  public createLink(options: {
+  public async createLink(options: {
     [key: string]: string
     customBase?: string
     name?: string
-  }): string {
-    const path = ['contact', this.address]
+  }): Promise<string> {
+    const path = ['contact', await this.getAddress()]
     const { customBase = defaultBaseUrl, ...rest } = options
     return utils.buildUrl(customBase, { path, query: rest })
   }
@@ -222,7 +222,7 @@ export class User {
    */
   public async requestEth(): Promise<string> {
     const options = {
-      body: JSON.stringify({ address: this.address }),
+      body: JSON.stringify({ address: await this.getAddress() }),
       headers: new Headers({ 'Content-Type': 'application/json' }),
       method: 'POST'
     }

--- a/src/signers/Web3Signer.ts
+++ b/src/signers/Web3Signer.ts
@@ -20,8 +20,6 @@ import {
  * The Web3Signer class contains functions for signing transactions with a web3 provider.
  */
 export class Web3Signer implements TLSigner {
-  public address: string
-
   private signer: ethers.providers.JsonRpcSigner
   private web3Provider: ethers.providers.Web3Provider
 

--- a/src/wallets/EthersWallet.ts
+++ b/src/wallets/EthersWallet.ts
@@ -38,6 +38,7 @@ export class EthersWallet implements TLWallet {
   // Accessors //
   ///////////////
 
+  // The address function is a convenient way to access to address in a synchronous method
   public get address(): string {
     if (!this.walletFromEthers) {
       throw new Error('No wallet loaded.')

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -66,6 +66,7 @@ export class IdentityWallet implements TLWallet {
     this.chainId = chainId
   }
 
+  // The address function is a convenient way to access to address in a synchronous method
   public get address(): string {
     if (!this.walletFromEthers) {
       throw new Error('No wallet loaded.')

--- a/src/wallets/TLWallet.ts
+++ b/src/wallets/TLWallet.ts
@@ -6,7 +6,6 @@ import { TLWalletData } from '../typings'
  */
 export interface TLWallet extends TLSigner {
   address: string
-  getAddress(): Promise<string>
   showSeed(): Promise<string>
   exportPrivateKey(): Promise<string>
   create(): Promise<TLWalletData>

--- a/tests/unit/User.test.ts
+++ b/tests/unit/User.test.ts
@@ -195,7 +195,7 @@ describe('unit', () => {
       const name = 'testname'
 
       it('should create trustlines:// link', async () => {
-        const contactLink = user.createLink({ name })
+        const contactLink = await user.createLink({ name })
         assert.equal(
           contactLink,
           `trustlines://contact/${user.address}?name=${name}`
@@ -203,7 +203,7 @@ describe('unit', () => {
       })
 
       it('should create trustlines:// link with queryParams', async () => {
-        const contactLink = user.createLink({
+        const contactLink = await user.createLink({
           name,
           param1: 'param1',
           param2: 'param2'
@@ -217,7 +217,7 @@ describe('unit', () => {
       })
 
       it('should create custom link', async () => {
-        const contactLink = user.createLink({
+        const contactLink = await user.createLink({
           name,
           customBase: 'http://custom.network'
         })


### PR DESCRIPTION
This makes the methods `createLink` and `requestEth` work with web3providers.

I decided not to remove the `address` method of User, it will raise an error if called when using a web3provider just as many other
method do (e.g. User.showSeed), and provides for a convenient way to access the user address when you know you are dealing with a local wallet.

I don't mind deciding the opposite if you think that's better.

closes: https://github.com/trustlines-protocol/clientlib/issues/190