### PR TITLE
Add documentation to getAll function of event to filter by contract

### DIFF
--- a/src/Event.ts
+++ b/src/Event.ts
@@ -89,12 +89,13 @@ export class Event {
   }
 
   /**
-   * Returns event logs of loaded user in all currency networks.
+   * Returns event logs of loaded user in all currency networks / EthWrappers / Exchanges.
    * @param filter Event filter object. See [[EventFilterOptions]] for more information.
    * @param filter.type Available event types are:
    *                    CurrencyNetwork -> `Transfer`, `TrustlineUpdateRequest` and `TrustlineUpdate`
    *                    EthWrapper -> `Transfer`, `Deposit` and `Withdrawal`
    *                    Exchange -> `LogFill` and `LogCancel`
+   * @param filter.contractType Available contract types are `CurrencyNetwork`, `Exchange`, `UnwETH`, `Token`
    * @param filter.fromBlock Start of block range for event logs.
    */
   public async getAll(filter: EventFilterOptions = {}): Promise<AnyEvent[]> {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -107,6 +107,7 @@ export interface Amount {
 // EVENTS
 export interface EventFilterOptions {
   type?: string
+  contractType?: 'CurrencyNetwork' | 'Exchange' | 'UnwETH' | 'Token'
   fromBlock?: number
 }
 


### PR DESCRIPTION
Adds documentation to query parameter to filter events in `getAll`, see: https://github.com/trustlines-protocol/relay/pull/542

Using this filter in the app can potentially speed up the querying of event, depending on whether the event database has events from other type of contracts.