### PR TITLE
Make the bump script user friendly

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -2,11 +2,16 @@
 
 # Run `yarn bump patch|minor|major` or `npm run bump -- patch|minor|major`
 
+if [ $# -eq 0 ]; then
+    echo "You ran the script with no arguments. Please use one of patch|minor|major"
+    exit 1
+fi
+
 # Add git tag and updated version in package.json
 yarn version --new-version "$@"
 
 # Prepare next version and omit git tag
-yarn version --new-version prepatch --no-git-tag-version 
+yarn version --new-version prepatch --no-git-tag-version
 
 git add package.json
 git commit -m "Update prepatch version"


### PR DESCRIPTION
If one ran `yarn bump` the bump script complained that no valid version was supplied, but it continued running and updated the current version and pushed to github. Unfortunately because no version was provided the script wasn’t able to create a git tag. With this change when no argument is provided the script stops executing and asks the user to provide the valid argument.