### PR TITLE
Add remainingData to the encoding of payment ExtraData

### DIFF
--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -95,9 +95,11 @@ export class Payment {
    * @param options.gasPrice Custom gas price.
    * @param options.gasLimit Custom gas limit.
    * @param options.feePayer Either `sender` or `receiver`. Specifies who pays network fees.
-   * @param options.extraData Extra data that will appear in the Transfer event when successful.
+   * @param options.extraData Extra data that will appear in the Transfer event when successful
+   *                          incompatible with paymentRequestId, addTransferId, and remainingData.
    * @param options.paymentRequestId Payment request identifier that gets encoded to the extra data.
    * @param options.addTransferId Whether a transfer id should be added to the payment, default to true.
+   * @param options.remainingData Additional data that will be encoded in the payment extraData.
    */
   public async prepare(
     networkAddress: string,
@@ -111,7 +113,8 @@ export class Payment {
       networkDecimals,
       extraData,
       paymentRequestId,
-      addTransferId
+      addTransferId,
+      remainingData
     } = options
     const decimals = await this.currencyNetwork.getDecimals(networkAddress, {
       networkDecimals
@@ -124,7 +127,8 @@ export class Payment {
     const encodedExtraData: string = encode({
       extraData,
       paymentRequestId,
-      transferId
+      transferId,
+      remainingData
     })
 
     const { path, maxFees, feePayer } = await this.getTransferPathInfo(
@@ -509,21 +513,23 @@ export class Payment {
 function encode({
   extraData,
   paymentRequestId,
-  transferId
+  transferId,
+  remainingData
 }: {
   extraData: string
   paymentRequestId: string
   transferId?: string
+  remainingData?: string
 }) {
-  if (extraData && (paymentRequestId || transferId)) {
+  if (extraData && (paymentRequestId || transferId || remainingData)) {
     throw Error(
-      'Can not encode extraData and paymentRequestId or transferId at the same time currently'
+      'Can not encode extraData and paymentRequestId or transferId or remainingData at the same time'
     )
   }
   if (extraData) {
     return extraData
-  } else if (paymentRequestId || transferId) {
-    return encodeExtraData({ paymentRequestId, transferId })
+  } else if (paymentRequestId || transferId || remainingData) {
+    return encodeExtraData({ paymentRequestId, transferId, remainingData })
   } else {
     return '0x'
   }

--- a/src/extraData.ts
+++ b/src/extraData.ts
@@ -5,16 +5,18 @@ export const MSG_PACK_ID = '0x544c4d50' // hex encoded "TLMP" (Trustlines Messag
 export interface ExtraData {
   paymentRequestId?: string
   transferId?: string
+  remainingData?: string
 }
 
 interface ExtraDataEncoding {
   prId?: ArrayBufferView
   trId?: ArrayBufferView
+  rest?: ArrayBufferView
 }
 
 export function encode(extraData: ExtraData): string {
-  const { paymentRequestId, transferId } = extraData
-  if (!paymentRequestId && !transferId) {
+  const { paymentRequestId, transferId, remainingData } = extraData
+  if (!paymentRequestId && !transferId && !remainingData) {
     return '0x'
   } else {
     const data: ExtraDataEncoding = {}
@@ -23,6 +25,9 @@ export function encode(extraData: ExtraData): string {
     }
     if (transferId) {
       data.trId = hexToArray(transferId)
+    }
+    if (remainingData) {
+      data.rest = hexToArray(remainingData)
     }
     const enc = msgPack.encode(data)
     return MSG_PACK_ID + remove0xPrefix(arrayToHex(enc))
@@ -52,7 +57,8 @@ export function decode(encodedExtraData: string): ExtraData {
 
   return {
     paymentRequestId: arrayToHex(extraData.prId),
-    transferId: arrayToHex(extraData.trId)
+    transferId: arrayToHex(extraData.trId),
+    remainingData: arrayToHex(extraData.rest)
   }
 }
 
@@ -81,7 +87,9 @@ function hexToArray(h: string) {
 export function processExtraData(object) {
   if (object.extraData !== undefined) {
     const decodedExtraData = decode(object.extraData)
-
+    object.remainingData = decodedExtraData
+      ? decodedExtraData.remainingData || null
+      : null
     object.paymentRequestId = decodedExtraData
       ? decodedExtraData.paymentRequestId || null
       : null

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -84,6 +84,7 @@ export interface PaymentOptions extends TLOptions {
   extraData?: string
   paymentRequestId?: string
   addTransferId?: boolean
+  remainingData?: string
 }
 
 export interface TrustlineUpdateOptions extends TLOptions {
@@ -143,6 +144,7 @@ export interface NetworkTransferEvent extends NetworkEvent {
   extraData: string
   paymentRequestId: string
   transferId: string
+  remainingData: string
 }
 
 export interface NetworkTrustlineUpdateEventRaw extends NetworkEvent {
@@ -737,6 +739,7 @@ export interface TransferDetails {
   extraData: string
   paymentRequestId: string
   transferId: string
+  remainingData: string
 }
 
 export interface TransferIdentifier {

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -63,6 +63,7 @@ export const parametrizedTLNetworkConfig = [
 
 export const extraData = '0x12ab34ef'
 export const paymentRequestId = '0x112233445566778899aa'
+export const remainingData = '0x1234'
 
 export async function createAndLoadUsers(tlInstances: TLNetwork[]) {
   return Promise.all(

--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -13,11 +13,13 @@ import {
   TokenAmountEvent
 } from '../../src/typings'
 
+import { encode } from '../../src/extraData'
 import {
   createAndLoadUsers,
   deployIdentities,
   extraData,
   paymentRequestId,
+  remainingData,
   requestEth,
   setTrustlines,
   tlNetworkConfig,
@@ -162,7 +164,7 @@ describe('e2e', () => {
           network2.address,
           user2.address,
           1,
-          { paymentRequestId }
+          { paymentRequestId, addTransferId: true, remainingData }
         )
         tlTransferTransferId = tlTransferTx.transferId
         tlTransferTxHash = await tl1.payment.confirm(tlTransferTx.rawTx)
@@ -334,11 +336,23 @@ describe('e2e', () => {
           (tlTransferEvents[0] as NetworkTransferEvent).amount
         ).to.have.keys('raw', 'decimals', 'value')
         expect(
+          (tlTransferEvents[0] as NetworkTransferEvent).extraData
+        ).to.equal(
+          encode({
+            paymentRequestId,
+            transferId: tlTransferTransferId,
+            remainingData
+          })
+        )
+        expect(
           (tlTransferEvents[0] as NetworkTransferEvent).paymentRequestId
         ).to.equal(paymentRequestId)
         expect(
           (tlTransferEvents[0] as NetworkTransferEvent).transferId
         ).to.equal(tlTransferTransferId)
+        expect(
+          (tlTransferEvents[0] as NetworkTransferEvent).remainingData
+        ).to.equal(remainingData)
 
         // events thrown on deposit
         const depositEvents = allEvents.filter(

--- a/tests/unit/extraData.test.ts
+++ b/tests/unit/extraData.test.ts
@@ -18,10 +18,18 @@ describe('unit', () => {
       )
     })
 
+    it('should encode and decode remainingData correctly', () => {
+      const extraData = { remainingData: '0x1234567890abcdef' }
+      expect(extraData.remainingData).to.be.deep.eq(
+        decode(encode(extraData)).remainingData
+      )
+    })
+
     it('should encode and decode combined extra data correctly', () => {
       const extraData = {
         paymentRequestId: '0x1212343456567878',
-        transferId: '0x1234567890abcdef'
+        transferId: '0x1234567890abcdef',
+        remainingData: '0x1234'
       }
       expect(extraData).to.be.deep.eq(decode(encode(extraData)))
     })


### PR DESCRIPTION
To prepare a payment, you can now provide `remainingData` as arbitrary data that will be encoded into the `extraData` that will end up on the chain. 
You can still ignore this field, together with `paymentRequestId` and `TransferId` and provide custom `extraData`.
This `remainingData` will also be returned in events and such.
Call me if that's too ambiguous.

closes https://github.com/trustlines-network/project/issues/859