### PR TITLE
Add support for payment request cancellation

### DIFF
--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -107,17 +107,20 @@ export class Messaging {
   /**
    * Sends a payment request cancel message to given `counterParty` and returns created message.
    * @param counterPartyAddress Address of counter party.
-   * @param id id of the payment request to decline
+   * @param id id of the payment request to cancel
    * matches either the nonce as a number or id of a payment request as a hex string.
+   * @param subject Optional subject of cancel message.
    */
   public async paymentRequestCancel(
     counterPartyAddress: string,
-    id: string
+    id: string,
+    subject?: string
   ): Promise<PaymentRequestDeclineMessage> {
     const type = 'PaymentRequestCancel'
     const message = {
       type,
-      id
+      id,
+      subject
     }
     await this.sendMessage(counterPartyAddress, type, message)
     return message

--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -105,6 +105,25 @@ export class Messaging {
   }
 
   /**
+   * Sends a payment request cancel message to given `counterParty` and returns created message.
+   * @param counterPartyAddress Address of counter party.
+   * @param id id of the payment request to decline
+   * matches either the nonce as a number or id of a payment request as a hex string.
+   */
+  public async paymentRequestCancel(
+    counterPartyAddress: string,
+    id: string
+  ): Promise<PaymentRequestDeclineMessage> {
+    const type = 'PaymentRequestCancel'
+    const message = {
+      type,
+      id
+    }
+    await this.sendMessage(counterPartyAddress, type, message)
+    return message
+  }
+
+  /**
    * Sends a payment message to given `counterParty` and returns created message.
    * @param counterPartyAddress Address of counter party.
    * @param transferId Transfer ID of the payment

--- a/tests/e2e/Messaging.test.ts
+++ b/tests/e2e/Messaging.test.ts
@@ -70,6 +70,17 @@ describe('e2e', () => {
         })
       })
 
+      describe('#paymentRequestCancel()', () => {
+        it('should return sent cancel', async () => {
+          const cancelMessage = await tl1.messaging.paymentRequestCancel(
+            tl2.user.address,
+            '0x10'
+          )
+          expect(cancelMessage.type).to.equal('PaymentRequestCancel')
+          expect(cancelMessage.id).to.equal('0x10')
+        })
+      })
+
       describe('#sendUsernameToCounterparty()', () => {
         it('should return sent username message', async () => {
           const sentUsernameMessage = await tl1.messaging.sendUsernameToCounterparty(

--- a/tests/e2e/Messaging.test.ts
+++ b/tests/e2e/Messaging.test.ts
@@ -74,10 +74,12 @@ describe('e2e', () => {
         it('should return sent cancel', async () => {
           const cancelMessage = await tl1.messaging.paymentRequestCancel(
             tl2.user.address,
-            '0x10'
+            '0x10',
+            'test subject'
           )
           expect(cancelMessage.type).to.equal('PaymentRequestCancel')
           expect(cancelMessage.id).to.equal('0x10')
+          expect(cancelMessage.subject).to.equal('test subject')
         })
       })
 


### PR DESCRIPTION
Adding method paymentRequestCancel that allows sending a message to
counterparty to cancel a pre-sent payment request.
Message will have PaymentRequestCancel type and includes payment
request id to be cancelled.