### PR TITLE
Fix trustline updates with transfer of "0"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,8 @@ jobs:
       DOCKER_REPO: trustlines/e2e
       LOCAL_IMAGE: e2e
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.7
       - checkout
       - run:
           name: Build docker image
@@ -117,7 +118,8 @@ jobs:
       DOCKER_REPO: trustlines/e2e
       LOCAL_IMAGE: e2e
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.7
       - attach_workspace:
           at: "~"
       - run:
@@ -140,7 +142,8 @@ jobs:
       DOCKER_REPO: trustlines/e2e
       LOCAL_IMAGE: e2e
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.7
       - attach_workspace:
           at: "~"
       - run:
@@ -163,7 +166,8 @@ jobs:
       DOCKER_REPO: trustlines/e2e
       LOCAL_IMAGE: e2e
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.7
       - attach_workspace:
           at: "~"
       - run:

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -144,6 +144,7 @@ export class Trustline {
       isFrozen,
       transfer
     } = options
+
     const [
       decimals,
       { customInterests, defaultInterestRate }
@@ -189,7 +190,16 @@ export class Trustline {
         ),
         isFrozen
       ]
-      if (transfer !== undefined && transfer !== 0) {
+
+      if (typeof transfer === 'string' && isNaN(parseFloat(transfer))) {
+        throw new Error('Transfer is not a number')
+      }
+
+      if (
+        transfer !== undefined &&
+        ((typeof transfer === 'string' && parseFloat(transfer) !== 0) ||
+          (typeof transfer === 'number' && transfer !== 0))
+      ) {
         updateFuncName =
           'updateTrustline(address,uint64,uint64,int16,int16,bool,int72)'
         updateFuncArgs = [


### PR DESCRIPTION
If we are triyng to update a trustline and we pass a transfer value of "0"(string) the clientlib will call the overloaded updateTrustline function of the contract. This causes the meta transaction to fail as there is already an existing trustline and when updating we shouldn't be passing a transfer value.
